### PR TITLE
Updates NavBarOption to allow passing a custom isCurrentPage function

### DIFF
--- a/web/src/components/nav_bar/nav_options.js
+++ b/web/src/components/nav_bar/nav_options.js
@@ -1,13 +1,22 @@
 import FeatureFlags from "../../infra/feature_flags";
 
 class NavOption {
-  constructor(displayName, url) {
+  constructor(displayName, url, isCurrentPageFunction) {
     this.displayName = displayName;
     this.url = url;
+    this.isCurrentPageFunction = isCurrentPageFunction;
+  }
+
+  defaultIsCurrentPage() {
+    return window.location.hash === this.url;
   }
 
   isCurrentPage() {
-    return window.location.hash === this.url;
+    if (this.isCurrentPageFunction) {
+      return this.isCurrentPageFunction();
+    } else {
+      return this.defaultIsCurrentPage();
+    }
   }
 }
 
@@ -15,7 +24,11 @@ function generateNavOptions() {
   let navOptions = [];
 
   if (FeatureFlags.showMenuOptions) {
-    navOptions.push(new NavOption("Home", "#/"));
+    navOptions.push(
+      new NavOption("Home", "#/", () => {
+        return window.location.hash === "#/" || window.location.hash === "";
+      })
+    );
   }
 
   if (FeatureFlags.showScheduleTab) {

--- a/web/src/components/nav_bar/nav_options.js
+++ b/web/src/components/nav_bar/nav_options.js
@@ -4,19 +4,11 @@ class NavOption {
   constructor(displayName, url, isCurrentPageFunction) {
     this.displayName = displayName;
     this.url = url;
-    this.isCurrentPageFunction = isCurrentPageFunction;
+    this.isCurrentPage = isCurrentPageFunction ?? this.defaultIsCurrentPage;
   }
 
   defaultIsCurrentPage() {
     return window.location.hash === this.url;
-  }
-
-  isCurrentPage() {
-    if (this.isCurrentPageFunction) {
-      return this.isCurrentPageFunction();
-    } else {
-      return this.defaultIsCurrentPage();
-    }
   }
 }
 
@@ -25,9 +17,11 @@ function generateNavOptions() {
 
   if (FeatureFlags.showMenuOptions) {
     navOptions.push(
-      new NavOption("Home", "#/", () => {
-        return window.location.hash === "#/" || window.location.hash === "";
-      })
+      new NavOption(
+        "Home",
+        "#/",
+        () => window.location.hash === "#/" || window.location.hash === ""
+      )
     );
   }
 


### PR DESCRIPTION
When the url had no hash, there was no nav bar highlight. Now it does highlight if there is no hash, there is an empty hash, etc.