### PR TITLE
Fix Welcome section for small screens

### DIFF
--- a/web/src/components/home/subcomponents/welcome/welcome.styles.js
+++ b/web/src/components/home/subcomponents/welcome/welcome.styles.js
@@ -14,7 +14,6 @@ const welcomeStyles = {
   },
   titleBox: {
     padding: "8vw",
-    whiteSpace: "nowrap",
   },
   startHereButton: {
     marginTop: "2rem",


### PR DESCRIPTION
Most common mobile screens are minimum 360px wide, so here's 360px screenshot.

#### Changes
- Removed nowrap on welcome section.
- Footer still is too wide, but welcome fits in mobile viewport

![image](https://github.com/doyourownswing/doyourownswing.github.io/assets/13969381/bc7eb06a-71e0-47ea-9d49-1414d6043e3b)
