### PR TITLE
Oooh ahh yes very pretty titles, better than bouncy round nunito

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -9,6 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"
       rel="stylesheet"
     />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Learn about Do Your Own Swing" />

--- a/web/src/common/theme.js
+++ b/web/src/common/theme.js
@@ -72,7 +72,7 @@ const theme = responsiveFontSizes(
         '"Segoe UI Symbol"',
       ].join(","),
       title: {
-        paddingBottom: "8px",
+        paddingBottom: "16px",
         fontWeight: "600",
         fontFamily: "Poppins",
       },

--- a/web/src/common/theme.js
+++ b/web/src/common/theme.js
@@ -59,6 +59,7 @@ const theme = responsiveFontSizes(
     typography: {
       fontFamily: [
         "Nunito",
+        "Poppins",
         "-apple-system",
         "BlinkMacSystemFont",
         '"Segoe UI"',
@@ -70,6 +71,11 @@ const theme = responsiveFontSizes(
         '"Segoe UI Emoji"',
         '"Segoe UI Symbol"',
       ].join(","),
+      title: {
+        paddingBottom: "8px",
+        fontWeight: "600",
+        fontFamily: "Poppins",
+      },
     },
   })
 );

--- a/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.js
+++ b/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.js
@@ -52,7 +52,7 @@ function SongOfTheWeek() {
   return (
     <Box sx={songOfTheWeekStyles.songOfTheWeekSection}>
       <Container>
-        <Typography variant="h4" sx={songOfTheWeekStyles.title}>
+        <Typography variant="h3" sx={songOfTheWeekStyles.title}>
           {messages.title}
         </Typography>
         <Stack

--- a/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.styles.js
+++ b/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.styles.js
@@ -20,8 +20,7 @@ const songOfTheWeekStyles = {
     },
   },
   title: {
-    paddingBottom: "8px",
-    // TODO: update the titles to be bold as per Vedant's suggestion
+    ...theme.typography.title,
   },
   leftContainer: {
     maxWidth: "400px",

--- a/web/src/components/home/subcomponents/upcoming_events/upcoming_events.js
+++ b/web/src/components/home/subcomponents/upcoming_events/upcoming_events.js
@@ -99,7 +99,7 @@ function UpcomingEvents() {
   return (
     <Box sx={upcomingEventsStyles.upcomingEventsContainer}>
       <Container>
-        <Typography variant="h4" sx={upcomingEventsStyles.title}>
+        <Typography variant="h3" sx={upcomingEventsStyles.title}>
           {messages.upcomingEventsTitle}
         </Typography>
         {FeatureFlags.showScheduleTab && (

--- a/web/src/components/home/subcomponents/upcoming_events/upcoming_events.styles.js
+++ b/web/src/components/home/subcomponents/upcoming_events/upcoming_events.styles.js
@@ -3,7 +3,7 @@ import { SECTION_PADDING } from "common/constants";
 
 const upcomingEventsStyles = {
   title: {
-    paddingBottom: "8px",
+    ...theme.typography.title,
   },
   twoEventRenderer: {
     paddingTop: "24px",

--- a/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.js
+++ b/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.js
@@ -7,7 +7,7 @@ function WhatIsWcs() {
   return (
     <Box sx={whatIsWcsStyles.whatIsWcsStylesContainer}>
       <Container>
-        <Typography variant="h4" sx={whatIsWcsStyles.header}>
+        <Typography variant="h3" sx={whatIsWcsStyles.header}>
           What is West Coast Swing?
         </Typography>
         <Box sx={whatIsWcsStyles.itemsContainer}>

--- a/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.styles.js
+++ b/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.styles.js
@@ -11,6 +11,7 @@ const whatIsWcsStyles = {
     alignItems: "center",
   },
   header: {
+    ...theme.typography.title,
     color: theme.palette.text.title,
     paddingBottom: "24px",
   },

--- a/web/src/components/home/subcomponents/who_we_are/who_we_are.js
+++ b/web/src/components/home/subcomponents/who_we_are/who_we_are.js
@@ -70,7 +70,7 @@ function WhoWeAre() {
   return (
     <Box sx={whoWeAreStyles.whoWeAreContainer}>
       <Container>
-        <Typography variant="h4" sx={whoWeAreStyles.title}>
+        <Typography variant="h3" sx={whoWeAreStyles.title}>
           {messages.title}
         </Typography>
         <Typography variant="body" sx={whoWeAreStyles.subtitle}>

--- a/web/src/components/home/subcomponents/who_we_are/who_we_are.styles.js
+++ b/web/src/components/home/subcomponents/who_we_are/who_we_are.styles.js
@@ -8,8 +8,8 @@ const whoWeAreStyles = {
     padding: SECTION_PADDING,
   },
   title: {
+    ...theme.typography.title,
     color: theme.palette.text.titleLight,
-    paddingBottom: "16px",
   },
   subtitle: {
     color: theme.palette.text.subtitleLight,


### PR DESCRIPTION
Gives each section a little more presence.

Tried using Nunito big and bold, but its too round and bouncy and feels like comic sans. Poppins has a little more edge which  grounds the page more.

<img width="796" alt="image" src="https://github.com/user-attachments/assets/0d8f13c8-ff6b-4ed9-a901-07f9c64b7d2e">

fixes #48 