### PR TITLE
More breathing room on small screens

### DIFF
--- a/web/src/common/constants.js
+++ b/web/src/common/constants.js
@@ -1,5 +1,5 @@
 export const SECTION_PADDING = {
-  xs: "48px 0px",
+  xs: "48px 16px",
   md: "80px 0px",
 };
 

--- a/web/src/common/theme.js
+++ b/web/src/common/theme.js
@@ -5,7 +5,9 @@ const basePalette = {
   darkPurple: "#260b34",
   purple: "#502268",
   mediumPurple: "#955ab5",
-  lightPurple: "#bf9ad3",
+  lightPurple1: "#bf9ad3",
+  lightPurple2: "#d4bce2",
+  lightPurple3: "#eaddf0",
   lightGray: "#ebebeb",
   white: "white",
 };
@@ -21,14 +23,13 @@ const theme = responsiveFontSizes(
       background: {
         light: basePalette.white,
         lightGray: basePalette.lightGray,
-        lightPurple: basePalette.lightPurple,
+        lightPurple: basePalette.lightPurple1,
         darkPurple: basePalette.darkPurple,
         songOfTheWeek: "linear-gradient(to bottom, #e9e0fb 0%, #ffe2f7 100%);",
         upcomingEvents: "linear-gradient(to bottom, #ffe2f7 0%, #e9e0fb 100%);",
       },
       text: {
         titleLight: basePalette.white,
-        subtitleLight: "#bbbbbb",
         title: basePalette.mediumPurple,
         subtitle: "#808080",
         // For less essential body text that we don't want to stand out as much.
@@ -36,12 +37,13 @@ const theme = responsiveFontSizes(
         // Same but slightly darker
         // TODO: update default quote with this in song of the week too once merging is done
         secondaryBody2: "#3f3f3f",
+        bodyLight: basePalette.lightPurple3,
         textButton: basePalette.mediumPurple,
         activeSelection: basePalette.mediumPurple,
         textLight: basePalette.white,
         linkLight: "#bbbbbb",
         linkLightHover: basePalette.white,
-        lightPurple: basePalette.lightPurple,
+        lightPurple: basePalette.lightPurple1,
         headerPurple: basePalette.purple,
         link: "#0F65D7",
         linkActive: "#174ea6",
@@ -53,7 +55,7 @@ const theme = responsiveFontSizes(
       },
       icon: {
         avatar: basePalette.purple,
-        lightPurple: basePalette.lightPurple,
+        lightPurple: basePalette.lightPurple1,
       },
     },
     typography: {

--- a/web/src/components/home/subcomponents/song_of_the_week/quote.styles.js
+++ b/web/src/components/home/subcomponents/song_of_the_week/quote.styles.js
@@ -7,6 +7,7 @@ const quoteStyles = {
     flexDirection: "column",
   },
   quote: {
+    fontSize: "18px",
     color: theme.palette.text.secondaryBody,
   },
 };

--- a/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.js
+++ b/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.js
@@ -11,11 +11,19 @@ const dyosPlaylistLink =
 
 function PlaylistCallout() {
   return (
-    <Box sx={songOfTheWeekStyles.quote}>
-      <Typography display="inline" variant="body1">
+    <Box>
+      <Typography
+        display="inline"
+        variant="body1"
+        sx={songOfTheWeekStyles.quotePlaceholder}
+      >
         {messages.noQuoteText.wannaKnow}
       </Typography>
-      <Typography display="inline" variant="body1">
+      <Typography
+        display="inline"
+        variant="body1"
+        sx={songOfTheWeekStyles.quotePlaceholder}
+      >
         <DyosLink href={dyosPlaylistLink} openInNewTab>
           {messages.noQuoteText.checkOut}
         </DyosLink>
@@ -27,10 +35,10 @@ function PlaylistCallout() {
 function AbbreviatedPlaylistCallout() {
   return (
     <Box>
-      <Typography display="inline" variant="subtitle2">
+      <Typography display="inline" variant="body1">
         {messages.abbreviatedPlaylistCallout.wannaKnow}
       </Typography>
-      <Typography display="inline" variant="subtitle2">
+      <Typography display="inline" variant="body1">
         <DyosLink href={dyosPlaylistLink} openInNewTab>
           {messages.abbreviatedPlaylistCallout.checkOut}
         </DyosLink>

--- a/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.styles.js
+++ b/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.styles.js
@@ -37,6 +37,9 @@ const songOfTheWeekStyles = {
     margin: "auto",
     marginRight: { md: 0 },
   },
+  quotePlaceholder: {
+    fontSize: "18px",
+  },
 };
 
 export default songOfTheWeekStyles;

--- a/web/src/components/home/subcomponents/upcoming_events/event_cards/dyos_event_card.styles.js
+++ b/web/src/components/home/subcomponents/upcoming_events/event_cards/dyos_event_card.styles.js
@@ -11,10 +11,18 @@ const dyosEventCardStyle = {
   left: {
     width: "48%",
     color: theme.palette.text.subtitle,
+    fontSize: {
+      xs: "14px",
+      sm: "16px",
+    },
   },
   right: {
     width: "48%",
     fontWeight: 600,
+    fontSize: {
+      xs: "14px",
+      sm: "16px",
+    },
   },
 };
 

--- a/web/src/components/home/subcomponents/upcoming_events/event_cards/event_card.js
+++ b/web/src/components/home/subcomponents/upcoming_events/event_cards/event_card.js
@@ -9,13 +9,17 @@ const HeaderDetails = (props) => (
     {props.date && (
       <Box sx={eventCardStyles.details}>
         <AccessTimeIcon sx={eventCardStyles.icon} />
-        <Typography>{dateToHumanReadableString(props.date)}</Typography>
+        <Typography sx={eventCardStyles.detailsText}>
+          {dateToHumanReadableString(props.date)}
+        </Typography>
       </Box>
     )}
     {props.location && (
       <Box sx={eventCardStyles.details}>
         <FmdGoodOutlinedIcon sx={eventCardStyles.icon} />
-        <Typography>{props.location}</Typography>
+        <Typography sx={eventCardStyles.detailsText}>
+          {props.location}
+        </Typography>
       </Box>
     )}
   </Box>

--- a/web/src/components/home/subcomponents/upcoming_events/event_cards/event_card.styles.js
+++ b/web/src/components/home/subcomponents/upcoming_events/event_cards/event_card.styles.js
@@ -4,7 +4,10 @@ import { BOX_SHADOW } from "common/constants";
 const eventCardStyles = {
   card: {
     padding: "24px",
-    minWidth: "320px",
+    minWidth: {
+      xs: "240px",
+      sm: "320px",
+    },
     borderRadius: "16px",
     backgroundColor: theme.palette.background.light,
     boxShadow: BOX_SHADOW,
@@ -16,9 +19,14 @@ const eventCardStyles = {
   },
   details: {
     display: "flex",
-    fontSize: "16px",
-    color: theme.palette.text.subtitle,
     marginTop: "8px",
+  },
+  detailsText: {
+    color: theme.palette.text.subtitle,
+    fontSize: {
+      xs: "14px",
+      sm: "16px",
+    },
   },
   icon: {
     color: "#320067",

--- a/web/src/components/home/subcomponents/welcome/messages.js
+++ b/web/src/components/home/subcomponents/welcome/messages.js
@@ -3,8 +3,8 @@ const messages = {
   title: "Do Your Own Swing",
   classesAndSocial:
     "West Coast Swing classes and social dancing in San Jose, CA.",
-  consciousSpace: "A COVID-Conscious, Queer-Led, 2SLGBTQIA+ Affirming Space 🌈",
-  thursdayNights: "Thursday Nights @ Studio M Ballroom",
+  consciousSpace: "A COVID-conscious, Queer-led, 2SLGBTQIA+ affirming space 🌈",
+  thursdayNights: "Thursday nights @ Studio M Ballroom",
   startHereText: "Start here if you're new",
 };
 

--- a/web/src/components/home/subcomponents/welcome/welcome.js
+++ b/web/src/components/home/subcomponents/welcome/welcome.js
@@ -10,32 +10,34 @@ function Welcome() {
   return (
     <Stack sx={welcomeStyles.sectionLayout}>
       <Stack justifyContent="center" sx={welcomeStyles.titleBox}>
-        <Box sx={welcomeStyles.titleText}>
-          <Typography variant="h4" color={theme.palette.text.secondary}>
-            {messages.discover}
-          </Typography>
-          <Typography
-            variant="h2"
-            sx={welcomeStyles.title}
-            color={theme.palette.text.title}
-          >
-            {messages.title}
-          </Typography>
+        <Box sx={welcomeStyles.firstSectionBox}>
+          <Box sx={welcomeStyles.titleText}>
+            <Typography variant="h4" color={theme.palette.text.secondary}>
+              {messages.discover}
+            </Typography>
+            <Typography
+              variant="h2"
+              sx={welcomeStyles.title}
+              color={theme.palette.text.title}
+            >
+              {messages.title}
+            </Typography>
+          </Box>
+          <Box sx={welcomeStyles.mainDescription}>
+            <Typography variant="body">{messages.classesAndSocial}</Typography>
+            <Typography variant="body">{messages.consciousSpace}</Typography>
+            <Typography variant="body">{messages.thursdayNights}</Typography>
+          </Box>
+          {FeatureFlags.showStartHerePage && (
+            <Button
+              variant="contained"
+              sx={welcomeStyles.startHereButton}
+              href="#/start-here"
+            >
+              {messages.startHereText}
+            </Button>
+          )}
         </Box>
-        <Box sx={welcomeStyles.mainDescription}>
-          <Typography variant="body">{messages.classesAndSocial}</Typography>
-          <Typography variant="body">{messages.consciousSpace}</Typography>
-          <Typography variant="body">{messages.thursdayNights}</Typography>
-        </Box>
-        {FeatureFlags.showStartHerePage && (
-          <Button
-            variant="contained"
-            sx={welcomeStyles.startHereButton}
-            href="#/start-here"
-          >
-            {messages.startHereText}
-          </Button>
-        )}
       </Stack>
       <Box
         component="img"

--- a/web/src/components/home/subcomponents/welcome/welcome.styles.js
+++ b/web/src/components/home/subcomponents/welcome/welcome.styles.js
@@ -14,8 +14,10 @@ const welcomeStyles = {
     aspectRatio: "3/2",
     overflow: "hidden",
   },
+  firstSectionBox: {
+    padding: { xs: "4vw", lg: "8vw" },
+  },
   titleBox: {
-    padding: "8vw",
     alignItems: { xs: "center", md: "start" },
   },
   titleText: {
@@ -23,12 +25,14 @@ const welcomeStyles = {
     flexDirection: "column",
     textWrap: "balance",
     alignItems: { xs: "center", md: "start" },
-    scale: { xs: "1.3", md: "1" },
   },
   title: {
+    // aligns the large text on the left
     marginLeft: "-2.5px",
   },
   startHereButton: {
+    display: "flex",
+    margin: { xs: "auto", md: "unset" },
     marginTop: "2rem",
     borderRadius: ".75rem",
     width: "fit-content",

--- a/web/src/components/home/subcomponents/who_we_are/who_we_are.js
+++ b/web/src/components/home/subcomponents/who_we_are/who_we_are.js
@@ -73,7 +73,7 @@ function WhoWeAre() {
         <Typography variant="h3" sx={whoWeAreStyles.title}>
           {messages.title}
         </Typography>
-        <Typography variant="body" sx={whoWeAreStyles.subtitle}>
+        <Typography variant="body" sx={whoWeAreStyles.description}>
           {messages.description}
         </Typography>
         <Box sx={whoWeAreStyles.valuesSection}>

--- a/web/src/components/home/subcomponents/who_we_are/who_we_are.styles.js
+++ b/web/src/components/home/subcomponents/who_we_are/who_we_are.styles.js
@@ -11,8 +11,9 @@ const whoWeAreStyles = {
     ...theme.typography.title,
     color: theme.palette.text.titleLight,
   },
-  subtitle: {
-    color: theme.palette.text.subtitleLight,
+  description: {
+    color: theme.palette.text.bodyLight,
+    fontSize: "18px",
   },
   valuesSection: {
     paddingTop: "64px",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  overflow-x: hidden;
 }
 
 code {


### PR DESCRIPTION
Firstly adds general 16px padding on the sides. Also hides overflow-x (only an issue on small screens, and not sure where it comes from)

Also makes song of the week quote and mission statement 2px larger

### Welcome screen
before:
<img width="432" alt="image" src="https://github.com/user-attachments/assets/94203fdf-138c-43d6-ba3c-cfb5f1ce7e26">


after:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/a52a8851-63c6-4316-8011-ceb61ae19cb1">

### Event card
before:
<img width="408" alt="image" src="https://github.com/user-attachments/assets/ddd014ae-7296-4ca3-a7c8-a5ffd6e96fb0">

after:
<img width="439" alt="image" src="https://github.com/user-attachments/assets/5339b3d5-7546-4923-b5b1-947861e1c594">

Fixes #54 
