### PR TITLE
Updates footer links to not span the whole screen on small screens

### DIFF
--- a/web/src/components/footer/subcomponents/browse/browse.styles.js
+++ b/web/src/components/footer/subcomponents/browse/browse.styles.js
@@ -8,8 +8,10 @@ const browseStyles = {
   },
   linkContainer: {
     marginTop: "8px",
+    width: "fit-content",
   },
   link: {
+    display: "block",
     color: theme.palette.text.linkLight,
     marginTop: "8px",
     "&:hover": {

--- a/web/src/components/footer/subcomponents/contact/contact.styles.js
+++ b/web/src/components/footer/subcomponents/contact/contact.styles.js
@@ -8,6 +8,7 @@ const contactStyles = {
   row: {
     display: "flex",
     marginTop: "8px",
+    width: "fit-content",
 
     color: theme.palette.text.linkLight,
     "&:hover": {

--- a/web/src/components/footer/subcomponents/location/location.styles.js
+++ b/web/src/components/footer/subcomponents/location/location.styles.js
@@ -7,8 +7,10 @@ const locationStyles = {
   },
   linkContainer: {
     marginTop: "8px",
+    width: "fit-content",
   },
   address: {
+    display: "block",
     color: theme.palette.text.linkLight,
     "&:hover": {
       color: theme.palette.text.linkLightHover,

--- a/web/src/components/footer/subcomponents/policies/policies.styles.js
+++ b/web/src/components/footer/subcomponents/policies/policies.styles.js
@@ -7,8 +7,10 @@ const policiesStyles = {
   },
   linkContainer: {
     marginTop: "8px",
+    width: "fit-content",
   },
   link: {
+    display: "block",
     color: theme.palette.text.linkLight,
     marginTop: "8px",
     "&:hover": {


### PR DESCRIPTION
on small screens, for some reason, the links will span the entire width of the screen. So if you try to scroll, you might accidentally click a link instead.

Now it's only the width of the text.

Fixes #55 