### PR TITLE
Creates a wrapper class to intersect and fix scrolling

### DIFF
--- a/web/src/index.js
+++ b/web/src/index.js
@@ -1,12 +1,6 @@
 import React, { useLayoutEffect } from "react";
 import ReactDOM from "react-dom/client";
-import {
-  createHashRouter,
-  HashRouter,
-  Route,
-  Routes,
-  useLocation,
-} from "react-router-dom";
+import { HashRouter, Route, Routes, useLocation } from "react-router-dom";
 import Footer from "components/footer/footer";
 import NavBar from "components/nav_bar/nav_bar";
 import ThemeProvider from "@mui/material/styles/ThemeProvider";
@@ -18,7 +12,6 @@ import generatedRoutes from "./page_registry";
 import Announcement from "components/nav_bar/announcement";
 import { getCurrentAnnouncement } from "data/announcements";
 
-const router = createHashRouter(generatedRoutes);
 const routes = generatedRoutes;
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
@@ -48,7 +41,6 @@ root.render(
       )}
       <NavBar />
       <Box sx={indexStyles.mainContent}>
-        {/* <RouterProvider router={router} /> */}
         <HashRouter>
           <ScrollResetContainer>
             <Routes>


### PR DESCRIPTION
HashRouter, the only one we can use with github pages, preserves the current location on page in between routes (pages in our case). This is bad UX cuz its a bit wonky.

To fix this, listen to changes in the location and reset scroll to top of page.

Tested locally and it works great. Shoutout to this guy https://medium.com/@caden0002/fixing-scroll-position-issues-in-react-router-scroll-to-top-on-navigation-86bcfbdfc9db

