### PR TITLE
Enable linking to home page components with HTML IDs

### DIFF
--- a/web/src/components/home/subcomponents/constants.js
+++ b/web/src/components/home/subcomponents/constants.js
@@ -1,0 +1,10 @@
+// HTML IDs for subcomponents on the home page.
+// These should be in kebab-case.
+export const HTML_IDS = {
+  ABOUT: "about",
+  EVENTS: "events",
+  MERCH: "merch",
+  SCHEDULE: "schedule",
+  SONG: "song",
+  WHAT_IS_WCS: "what-is-wcs",
+};

--- a/web/src/components/home/subcomponents/merch/merch.css
+++ b/web/src/components/home/subcomponents/merch/merch.css
@@ -1,5 +1,5 @@
 /* Time is also based on number of images. Advise 4 * numImages. */
-#carousel-content {
+.carousel-content {
   animation: infinite-carousel 24s linear infinite;
 }
 

--- a/web/src/components/home/subcomponents/merch/merch.jsx
+++ b/web/src/components/home/subcomponents/merch/merch.jsx
@@ -10,6 +10,7 @@ import merch4 from "@/assets/images/merch/im_shy_tee_unisex.webp";
 import merch5 from "@/assets/images/merch/dyos_stacked_unisex.webp";
 import merch6 from "@/assets/images/merch/heart_pocket_tee.webp";
 import { Space, Text } from "@/components/common/typography";
+import { HTML_IDS } from "../constants";
 
 const googleFormLink =
   "https://docs.google.com/forms/d/e/1FAIpQLSeoUWA8LICvFhxhwiYBqWAjDxOZta1LgnPzkWtaWAoXQ1UESQ/viewform?usp=header";
@@ -24,13 +25,13 @@ const doubledShirts = [...shirts, ...shirts];
 
 export default function Merch() {
   return (
-    <Box sx={merchStyles.sectionContainer}>
+    <Box id={HTML_IDS.MERCH} sx={merchStyles.sectionContainer}>
       <Container sx={merchStyles.content}>
         <Typography variant="h3" sx={merchStyles.title}>
           {messages.title}
         </Typography>
         <Box sx={merchStyles.carouselContainer}>
-          <Box sx={merchStyles.carouselContent} id="carousel-content">
+          <Box sx={merchStyles.carouselContent} className="carousel-content">
             {doubledShirts.map((s, i) => (
               <Box component="img" src={s} key={i} sx={merchStyles.image}></Box>
             ))}

--- a/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.jsx
+++ b/web/src/components/home/subcomponents/song_of_the_week/song_of_the_week.jsx
@@ -5,6 +5,7 @@ import getCurrentSong from "@/data/songs_of_the_week";
 import messages from "./messages";
 import Quote from "./quote";
 import DyosLink from "@/components/common/link";
+import { HTML_IDS } from "../constants";
 
 const dyosPlaylistLink =
   "https://open.spotify.com/playlist/4pI5RuxmGMy0uyANUqGAyE?si=411919e6ece04cc7";
@@ -58,7 +59,7 @@ function SongOfTheWeek() {
   let hasQuote = !!songInfo.quoteInfo;
 
   return (
-    <Box sx={songOfTheWeekStyles.songOfTheWeekSection}>
+    <Box id={HTML_IDS.SONG} sx={songOfTheWeekStyles.songOfTheWeekSection}>
       <Container>
         <Typography variant="h3" sx={songOfTheWeekStyles.title}>
           {messages.title}

--- a/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.jsx
+++ b/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.jsx
@@ -18,6 +18,8 @@ import { getNextThursday } from "@/utils/date_utils";
 import messages from "@/components/home/subcomponents/upcoming_events_v2/messages";
 import Callout from "@/components/common/callout";
 
+import { HTML_IDS } from "../constants";
+
 function ScheduleEvent(props) {
   let details = props.details;
 
@@ -146,7 +148,7 @@ function CurrentMonthEvents() {
   let nextThursday = getNextThursday();
 
   return (
-    <Box sx={upcomingEventsV2Styles.monthEventsContainer}>
+    <Box id={HTML_IDS.EVENTS} sx={upcomingEventsV2Styles.monthEventsContainer}>
       <Box>
         <Box>
           {/* TODO support paging through multiple months */}
@@ -177,7 +179,7 @@ function CurrentMonthEvents() {
 
 const UpcomingEventsV2 = forwardRef(function UpcomingEventsV2(_, ref) {
   return (
-    <Box ref={ref} sx={upcomingEventsV2Styles.container}>
+    <Box id={HTML_IDS.SCHEDULE} ref={ref} sx={upcomingEventsV2Styles.container}>
       <Container>
         <Typography variant="h3" sx={upcomingEventsV2Styles.title}>
           {messages.title}

--- a/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.jsx
+++ b/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.jsx
@@ -15,6 +15,8 @@ import "./what_is_wcs.css";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 
+import { HTML_IDS } from "../constants";
+
 // Saumya put together this doc for us:
 // https://docs.google.com/document/d/1hb9Ho3YnDe_uF4PUB-MfbJBytIC3B6heCXoBB-MPBrU/edit?tab=t.0
 
@@ -277,7 +279,7 @@ const paragraphs = [
 // The What is West Coast Swing section renderer.
 function WhatIsWcs() {
   return (
-    <Box sx={whatIsWcsStyles.whatIsWcsStylesContainer}>
+    <Box id={HTML_IDS.WHAT_IS_WCS} sx={whatIsWcsStyles.whatIsWcsStylesContainer}>
       <Container>
         <Typography variant="h3" sx={whatIsWcsStyles.header}>
           {messages.title}

--- a/web/src/components/home/subcomponents/who_we_are/who_we_are.jsx
+++ b/web/src/components/home/subcomponents/who_we_are/who_we_are.jsx
@@ -8,6 +8,7 @@ import {
   Handshake,
 } from "@mui/icons-material";
 import Grid from '@mui/material/Grid';
+import { HTML_IDS } from "../constants";
 
 // Icons are from:
 // https://mui.com/material-ui/material-icons/
@@ -68,7 +69,7 @@ function ValuesRenderer() {
 
 function WhoWeAre() {
   return (
-    <Box sx={whoWeAreStyles.whoWeAreContainer}>
+    <Box id={HTML_IDS.ABOUT} sx={whoWeAreStyles.whoWeAreContainer}>
       <Container>
         <Typography variant="h3" sx={whoWeAreStyles.title}>
           {messages.title}


### PR DESCRIPTION
Minor feature! This PR adds ids to some home page components that might make sense as elements to link to, so that we can share links like `doyourownswing.com/#merch` or `doyourownswing.com/#schedule`