### PR TITLE
Fix homepage typos

### DIFF
--- a/web/src/common/messages.js
+++ b/web/src/common/messages.js
@@ -1,6 +1,5 @@
 const messages = {
   doYourOwnSwing: "Do Your Own Swing",
-  doYourOwnSwingYear: "Do Your Own Swing 2025",
   dyos: "DYOS",
   miniDyos: "Mini DYOS",
   missionStatement: `

--- a/web/src/components/footer/subcomponents/brand/brand.jsx
+++ b/web/src/components/footer/subcomponents/brand/brand.jsx
@@ -4,6 +4,7 @@ import messages from "@/common/messages";
 import { ColorLogo } from "@/components/common/logos";
 
 function Brand() {
+  const thisYear = new Date().getFullYear();
   return (
     <Box sx={brandStyles.brandContainerContainer}>
       <Box>
@@ -11,7 +12,9 @@ function Brand() {
           <ColorLogo sx={brandStyles.logoImage} />
           <Typography sx={brandStyles.logoText}>{messages.dyos}</Typography>
         </Box>
-        <Typography variant="caption">{messages.doYourOwnSwingYear}</Typography>
+        <Typography variant="caption">
+          {messages.doYourOwnSwing} {thisYear}
+        </Typography>
       </Box>
     </Box>
   );

--- a/web/src/data/events_v2.js
+++ b/web/src/data/events_v2.js
@@ -5,7 +5,7 @@ import { createDate, getNextThursday } from "@/utils/date_utils";
 const L1_TOPICS = {
   week1: "Left side pass, underarm pass, sugar push",
   week2: "Whip",
-  week3: "Underarm pass, sugar push, and sugar tuck",
+  week3: "Underarm pass, sugar push, sugar tuck",
   week4: "Left side pass, sugar push, spinning side pass",
 };
 
@@ -38,7 +38,7 @@ const events = [
     facebookLink: "https://www.facebook.com/events/1227344559457439/",
   },
   {
-    date: createDate("01/28/2026"),
+    date: createDate("01/29/2026"),
     title: "Footwork Variations week 4",
     subtitle: "Exploring classic blues patterns!",
     advanceTopic: "",


### PR DESCRIPTION
- Changes one of the upcoming event dates from January 28 (Wed) to January 29 (Thu)
- Updates the footer to include the current year instead of being hardcoded to 2025
- Removes a stray "and" from the list of L1 class topics