### PR TITLE
Different copy for Who We Are section of home page

### DIFF
--- a/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.jsx
+++ b/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.jsx
@@ -26,22 +26,14 @@ import { HTML_IDS } from "../constants";
 
 /// A renderer for each paragraph that has a bolded "hook", and the
 /// rest has the regular body styling
-function BasicParagraphFormatter(props) {
+export function BasicParagraphFormatter({ content, hookStyle, contentStyle }) {
   return (
     <Box>
-      <Typography
-        display="inline"
-        variant="body1"
-        sx={whatIsWcsStyles.pointHook}
-      >
-        {props.content.hook}
+      <Typography display="inline" variant="body1" sx={hookStyle}>
+        {content.hook}
       </Typography>
-      <Typography
-        display="inline"
-        variant="body1"
-        sx={whatIsWcsStyles.pointContent}
-      >
-        {props.content.content}
+      <Typography display="inline" variant="body1" sx={contentStyle}>
+        {content.content}
       </Typography>
     </Box>
   );
@@ -279,7 +271,10 @@ const paragraphs = [
 // The What is West Coast Swing section renderer.
 function WhatIsWcs() {
   return (
-    <Box id={HTML_IDS.WHAT_IS_WCS} sx={whatIsWcsStyles.whatIsWcsStylesContainer}>
+    <Box
+      id={HTML_IDS.WHAT_IS_WCS}
+      sx={whatIsWcsStyles.whatIsWcsStylesContainer}
+    >
       <Container>
         <Typography variant="h3" sx={whatIsWcsStyles.header}>
           {messages.title}
@@ -291,7 +286,11 @@ function WhatIsWcs() {
               spacing={{ xs: 1, md: 4 }}
             >
               {paragraphs.map((p) => (
-                <BasicParagraphFormatter content={p} />
+                <BasicParagraphFormatter
+                  content={p}
+                  hookStyle={whatIsWcsStyles.pointHook}
+                  contentStyle={whatIsWcsStyles.pointContent}
+                />
               ))}
             </Stack>
             <VideoSection />

--- a/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.styles.js
+++ b/web/src/components/home/subcomponents/what_is_wcs/what_is_wcs.styles.js
@@ -35,6 +35,7 @@ const whatIsWcsStyles = {
   },
   pointContent: {
     fontSize: "1rem",
+    textWrap: "pretty",
   },
   videoContainer: {
     display: {

--- a/web/src/components/home/subcomponents/who_we_are/messages.js
+++ b/web/src/components/home/subcomponents/who_we_are/messages.js
@@ -1,10 +1,26 @@
-import { default as commonMessages } from "@/common/messages";
-
 const messages = {
-  title: "Who we are",
+  title: "Why DYOS?",
   // TODO: add links to about us and code of conduct pages behind feature flag.
-  description: commonMessages.missionStatement,
-  ourCommunityValues: "Our community values",
+  description:
+    "You'll love learning and dancing West Coast Swing at DYOS. Here's why:",
+  points: [
+    {
+      hook: "Welcoming instruction from day 1. ",
+      content:
+        "Our L1 classes are for everyone, even if you've never danced before! Our rotating instructors will help you see concepts in new ways each week. Already know some basics? L2 class topics are based on your questions, so you can feel confident leveling up your dance.",
+    },
+    {
+      hook: "Inclusivity by default. ",
+      content:
+        "We care about keeping our community safe. We always require well-fitting masks during classes.",
+    },
+    {
+      hook: "Community-first events. ",
+      content:
+        "We keep the social dance experience fresh with celebration dance jams, potlucks, line dances, and more.",
+    },
+  ],
+  ourCommunityValues: "Our values",
 };
 
 export default messages;

--- a/web/src/components/home/subcomponents/who_we_are/who_we_are.jsx
+++ b/web/src/components/home/subcomponents/who_we_are/who_we_are.jsx
@@ -1,4 +1,4 @@
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Container, Stack, Typography } from "@mui/material";
 import whoWeAreStyles from "./who_we_are.styles";
 import messages from "./messages";
 import {
@@ -7,8 +7,9 @@ import {
   Favorite,
   Handshake,
 } from "@mui/icons-material";
-import Grid from '@mui/material/Grid';
+import Grid from "@mui/material/Grid";
 import { HTML_IDS } from "../constants";
+import { BasicParagraphFormatter } from "../what_is_wcs/what_is_wcs";
 
 // Icons are from:
 // https://mui.com/material-ui/material-icons/
@@ -77,6 +78,15 @@ function WhoWeAre() {
         <Typography variant="body" sx={whoWeAreStyles.description}>
           {messages.description}
         </Typography>
+        <Stack sx={whoWeAreStyles.pointsSection} spacing={{ xs: 1, md: 2 }}>
+          {messages.points.map((p) => (
+            <BasicParagraphFormatter
+              content={p}
+              hookStyle={whoWeAreStyles.pointHook}
+              contentStyle={whoWeAreStyles.pointContent}
+            />
+          ))}
+        </Stack>
         <Box sx={whoWeAreStyles.valuesSection}>
           <Typography variant="h6">{messages.ourCommunityValues}</Typography>
           <ValuesRenderer></ValuesRenderer>

--- a/web/src/components/home/subcomponents/who_we_are/who_we_are.styles.js
+++ b/web/src/components/home/subcomponents/who_we_are/who_we_are.styles.js
@@ -1,5 +1,6 @@
 import { SECTION_PADDING } from "@/common/constants";
 import theme from "@/common/theme";
+import whatIsWcsStyles from "../what_is_wcs/what_is_wcs.styles";
 
 const whoWeAreStyles = {
   whoWeAreContainer: {
@@ -15,8 +16,19 @@ const whoWeAreStyles = {
     color: theme.palette.text.bodyLight,
     fontSize: "18px",
   },
+  pointsSection: {
+    paddingTop: "24px",
+  },
+  pointHook: {
+    ...whatIsWcsStyles.pointHook,
+    color: theme.palette.text.titleLight,
+  },
+  pointContent: {
+    ...whatIsWcsStyles.pointContent,
+    color: theme.palette.text.bodyLight,
+  },
   valuesSection: {
-    paddingTop: "64px",
+    paddingTop: "32px",
   },
   valueRenderer: {
     display: "inline-flex",
@@ -31,7 +43,6 @@ const whoWeAreStyles = {
   },
   valuesContainer: {
     paddingTop: "24px",
-    paddingBottom: "24px",
   },
   valueIcon: {
     color: theme.palette.icon.lightPurple,


### PR DESCRIPTION
One of the lower-priority to-do items we talked about at the start of this month was to change the text on this part of the homepage from the mission statement to a better description of why people should come to DYOS. I gave it a shot based on the mission statement + google reviews + what I personally like and think makes it unique... but I'm sure this will need some edits since I'm not a copywriter and I don't actually know what draws more advanced dancers to DYOS 😅 

This reuses the paragraph formatting from the "What Is WCS?" section. 

Here's what it looks like on mobile and desktop screen sizes:

<img width="388" height="680" alt="mobile preview" src="https://github.com/user-attachments/assets/adb6759d-0821-40b7-8a00-66c054f1d0f5" />

<img width="1411" height="671" alt="desktop preview" src="https://github.com/user-attachments/assets/028ae972-d173-456d-8fc3-5c74468913fc" />
