### PR TITLE
Add events for February 2026

### DIFF
--- a/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.jsx
+++ b/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.jsx
@@ -148,7 +148,6 @@ function CurrentMonthEvents() {
   let nextThursday = getNextThursday();
 
   // If events haven't been added for this month yet, don't show the schedule
-  // TODO: consider linking to FB/Instagram instead?
   if (events.length === 0) {
     return null;
   }

--- a/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.jsx
+++ b/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.jsx
@@ -147,6 +147,12 @@ function CurrentMonthEvents() {
   let events = getThisMonthsEvents();
   let nextThursday = getNextThursday();
 
+  // If events haven't been added for this month yet, don't show the schedule
+  // TODO: consider linking to FB/Instagram instead?
+  if (events.length === 0) {
+    return null;
+  }
+
   return (
     <Box id={HTML_IDS.EVENTS} sx={upcomingEventsV2Styles.monthEventsContainer}>
       <Box>

--- a/web/src/data/events_v2.js
+++ b/web/src/data/events_v2.js
@@ -52,7 +52,7 @@ const events = [
     subtitle: "Let's level up some classic blues patterns",
     advanceTopic: "",
     levelOneTopic: L1_TOPICS.week1,
-    dj: "",
+    dj: "Jake",
     facebookLink: "https://www.facebook.com/events/877189058035030/",
   },
   {
@@ -60,6 +60,20 @@ const events = [
     noDyos: true,
     title: "Capital Swing weekend",
     subtitle: "See you next week!",
+  },
+  {
+    date: createDate("02/19/2026"),
+    advanceTopic: "",
+    levelOneTopic: L1_TOPICS.week2,
+    dj: "International Music Night!",
+    facebookLink: "https://www.facebook.com/events/2444016136031608/",
+  },
+  {
+    date: createDate("02/26/2026"),
+    advanceTopic: "",
+    levelOneTopic: L1_TOPICS.week3,
+    dj: "Saumya",
+    facebookLink: "https://www.facebook.com/events/876192111459926/",
   },
 ];
 
@@ -77,7 +91,7 @@ const events = [
 function getThisMonthsEvents() {
   let thisMonth = getNextThursday().month();
 
-  return events.filter((event) => event.date.month() == thisMonth);
+  return events.filter((event) => event.date.month() === thisMonth);
 }
 
 export default getThisMonthsEvents;

--- a/web/src/data/events_v2.js
+++ b/web/src/data/events_v2.js
@@ -62,6 +62,8 @@ const events = [
     subtitle: "See you next week!",
   },
   {
+    title: "A Deep Dive into Connection week 1",
+    subtitle: "The secret sauce behind WCS improvisation!",
     date: createDate("02/19/2026"),
     advanceTopic: "",
     levelOneTopic: L1_TOPICS.week2,
@@ -69,6 +71,8 @@ const events = [
     facebookLink: "https://www.facebook.com/events/2444016136031608/",
   },
   {
+    title: "A Deep Dive into Connection week 2",
+    subtitle: "Creating conversations through the connection",
     date: createDate("02/26/2026"),
     advanceTopic: "",
     levelOneTopic: L1_TOPICS.week3,

--- a/web/src/utils/date_utils.js
+++ b/web/src/utils/date_utils.js
@@ -33,7 +33,14 @@ function getBeginningOfTodayDate() {
 }
 
 function getNextThursday() {
-  return dayjs(new Date()).day(4);
+  // if it's Friday or Saturday, get next week'sThursday
+  const today = dayjs(new Date());
+  if (today.day() >= 5) {
+    return today.day(11);
+  }
+
+  // otherwise, get this week's Thursday
+  return today.day(4);
 }
 
 export {

--- a/web/src/utils/date_utils.js
+++ b/web/src/utils/date_utils.js
@@ -33,7 +33,7 @@ function getBeginningOfTodayDate() {
 }
 
 function getNextThursday() {
-  // if it's Friday or Saturday, get next week'sThursday
+  // if it's Friday or Saturday, get next week's Thursday
   const today = dayjs(new Date());
   if (today.day() >= 5) {
     return today.day(11);


### PR DESCRIPTION
Three changes relating to the events section of the front page:
- Add the last 2 classes for February, linked to the correct FB events
- If we don't have events for a month, hide the events module instead of showing a page section with no events in it
- Make `getNextThursday` return the upcoming Thursday instead of the Thursday of the current week (this only matters if it's a Friday or Saturday and the next Thursday is in next month)

<img width="803" height="597" alt="preview screenshot with February events" src="https://github.com/user-attachments/assets/ee271095-3aeb-4879-8263-0017ad4196c4" />
