### PR TITLE
Fix hash link URLs to actually scroll to elements

### DIFF
--- a/web/src/common/ScrollToHashElement.jsx
+++ b/web/src/common/ScrollToHashElement.jsx
@@ -1,0 +1,36 @@
+/* taken from https://ncoughlin.com/posts/react-router-v6-hash-links/ */
+
+import { useMemo, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToHashElement = () => {
+  let location = useLocation();
+
+  let hashElement = useMemo(() => {
+    let hash = location.hash;
+    const removeHashCharacter = (str) => {
+      const result = str.slice(1);
+      return result;
+    };
+
+    if (hash) {
+      let element = document.getElementById(removeHashCharacter(hash));
+      return element;
+    } else {
+      return null;
+    }
+  }, [location]);
+
+  useEffect(() => {
+    if (hashElement) {
+      hashElement.scrollIntoView({
+        behavior: "smooth",
+        inline: "nearest",
+      });
+    }
+  }, [hashElement]);
+
+  return null;
+};
+
+export default ScrollToHashElement;

--- a/web/src/common/ScrollToHashElement.jsx
+++ b/web/src/common/ScrollToHashElement.jsx
@@ -1,34 +1,31 @@
-/* taken from https://ncoughlin.com/posts/react-router-v6-hash-links/ */
+/* code modified from https://ncoughlin.com/posts/react-router-v6-hash-links/ */
 
-import { useMemo, useEffect } from "react";
+import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
+// This wrapper listens to page change events for two reasons:
+// (1) React Router preserves scroll location between routes.
+//     This is undesired behavior. We want to scroll to the top for new pages.
+// (2) We want to scroll to the element indicated by the hash / anchor link,
+//     if any.
 const ScrollToHashElement = () => {
-  let location = useLocation();
-
-  let hashElement = useMemo(() => {
-    let hash = location.hash;
-    const removeHashCharacter = (str) => {
-      const result = str.slice(1);
-      return result;
-    };
-
-    if (hash) {
-      let element = document.getElementById(removeHashCharacter(hash));
-      return element;
-    } else {
-      return null;
-    }
-  }, [location]);
+  const location = useLocation();
 
   useEffect(() => {
+    // Get only the value following the # in the URL
+    const hashValue = location.hash.slice(1);
+    const hashElement = hashValue ? document.getElementById(hashValue) : null;
+
     if (hashElement) {
+      // Scroll to the element indicated by a hash
       hashElement.scrollIntoView({
         behavior: "smooth",
-        inline: "nearest",
       });
+    } else {
+      // Scroll to the top of the page when the route changes
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
     }
-  }, [hashElement]);
+  }, [location.hash, location.pathname]);
 
   return null;
 };

--- a/web/src/components/home/home.jsx
+++ b/web/src/components/home/home.jsx
@@ -4,29 +4,14 @@ import SongOfTheWeek from "./subcomponents/song_of_the_week/song_of_the_week";
 import WhatIsWcs from "./subcomponents/what_is_wcs/what_is_wcs";
 import WhoWeAre from "./subcomponents/who_we_are/who_we_are";
 import FeatureFlags from "@/infra/feature_flags";
-import { useRef } from "react";
 import Merch from "./subcomponents/merch/merch";
-import WinterSchedule from "./subcomponents/winter_schedule_2025/winter_schedule";
 import UpcomingEventsV2 from "@/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2";
 
 export default function Home() {
-  const upcomingEventsRef = useRef(null);
-
-  const onClickPrimaryHeroButton = () =>
-    upcomingEventsRef.current.scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-    });
-
   return (
     <Box>
-      <Hero onClickPrimaryButton={onClickPrimaryHeroButton} />
-      {!FeatureFlags.useUpcomingEventsV2 && (
-        <WinterSchedule ref={upcomingEventsRef} />
-      )}
-      {FeatureFlags.useUpcomingEventsV2 && (
-        <UpcomingEventsV2 ref={upcomingEventsRef} />
-      )}
+      <Hero />
+      <UpcomingEventsV2 />
       <WhoWeAre />
       <WhatIsWcs />
       <SongOfTheWeek />

--- a/web/src/components/home/subcomponents/hero/hero.jsx
+++ b/web/src/components/home/subcomponents/hero/hero.jsx
@@ -15,6 +15,8 @@ import { StartHere } from "@/common/pages";
 import messages from "./messages";
 import heroStyles from "./hero.styles";
 import "./hero.css";
+import { HTML_IDS } from "../constants";
+import { useNavigate } from "react-router-dom";
 
 const newYorkTimesLink =
   "https://www.removepaywall.com/search?url=https://www.nytimes.com/2024/12/23/arts/dance/west-coast-swing-dance.html";
@@ -23,7 +25,9 @@ const animationIterationEventName = "animationiteration";
 
 const adjectiveContainerId = "adjective-container";
 
-function Hero(props) {
+function Hero() {
+  const navigate = useNavigate();
+
   const smallestScreenSize = useMediaQuery(theme.breakpoints.down("sm"));
   const adjectiveContainerClass = smallestScreenSize
     ? "adjective-xs"
@@ -86,7 +90,7 @@ function Hero(props) {
                 sx={heroStyles.primaryButton}
                 variant="contained"
                 color={theme.palette.buttonLight.name}
-                onClick={props.onClickPrimaryButton}
+                onClick={() => navigate("#" + HTML_IDS.SCHEDULE)}
               >
                 {messages.primaryButton}
               </Button>

--- a/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.styles.js
+++ b/web/src/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2.styles.js
@@ -19,6 +19,7 @@ const upcomingEventsV2Styles = {
   container: {
     padding: SECTION_PADDING,
     background: theme.palette.background.barelyPurple,
+    scrollMarginTop: { xs: "2rem" },
   },
   title: {
     ...theme.typography.title,

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -9,6 +9,7 @@ import "./index.css";
 import { Box } from "@mui/material";
 import { generatedRoutes, Overrides } from "./page_registry";
 import { useLocation } from "react-router-dom";
+import ScrollToHashElement from "./common/ScrollToHashElement";
 
 const routes = generatedRoutes;
 
@@ -63,6 +64,7 @@ function App() {
       <ThemeProvider theme={theme}>
         <Box>
           <BrowserRouter>
+            <ScrollToHashElement />
             <NavBarAndAnnouncementsRenderer />
             <ScrollResetContainer>
               <Routes>

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from "react";
+import React from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Footer from "@/components/footer/footer";
@@ -12,20 +12,6 @@ import { useLocation } from "react-router-dom";
 import ScrollToHashElement from "./common/ScrollToHashElement";
 
 const routes = generatedRoutes;
-
-// React Router preserves scroll location between various routes.
-// This is undesired behavior. This wrapper listens to page change events
-// and will scroll to the top in new pages.
-function ScrollResetContainer(props) {
-  const location = useLocation();
-
-  useLayoutEffect(() => {
-    // Scroll to the top of the page when the route changes
-    window.scrollTo({ top: 0, left: 0, behavior: "instant" });
-  }, [location.pathname]);
-
-  return props.children;
-}
 
 function NavBarAndAnnouncementsRenderer() {
   let currentRoute = routes.find((r) => r.page.isCurrentPage());
@@ -66,13 +52,11 @@ function App() {
           <BrowserRouter>
             <ScrollToHashElement />
             <NavBarAndAnnouncementsRenderer />
-            <ScrollResetContainer>
-              <Routes>
-                {routes.map((r, i) => (
-                  <Route key={i} path={r.path} element={r.element} />
-                ))}
-              </Routes>
-            </ScrollResetContainer>
+            <Routes>
+              {routes.map((r, i) => (
+                <Route key={i} path={r.path} element={r.element} />
+              ))}
+            </Routes>
             <FooterRenderer />
           </BrowserRouter>
         </Box>


### PR DESCRIPTION
Hash links / anchor links (as introduced in #159) don't work out of the box with React Router. This PR fixes them with the solution from [this blog post](https://ncoughlin.com/posts/react-router-v6-hash-links/).

This also means we can use react-router to navigate to links with hashes in them. As an example of this, I replaced the use of scrollIntoView on the home page with a direct link. This won't change the behavior of the button. 