### PR TITLE
Allow some paths to redirect to other sites

### DIFF
--- a/web/src/common/constants.js
+++ b/web/src/common/constants.js
@@ -27,3 +27,4 @@ export const MAILTO_DYOS_EMAIL = "mailto:doyourownswing@gmail.com";
 export const DYOS_DISCORD_LINK = "https://discord.gg/EwXq7EYS7e";
 export const DYOS_FACEBOOK_LINK = "https://www.facebook.com/doyourownswing";
 export const DYOS_INSTAGRAM_LINK = "https://www.instagram.com/doyourownswing";
+export const MERCH_STORE_LINK = "https://doyourownswing.printful.me/";

--- a/web/src/components/home/subcomponents/merch/merch.jsx
+++ b/web/src/components/home/subcomponents/merch/merch.jsx
@@ -14,7 +14,7 @@ import { HTML_IDS } from "../constants";
 
 const googleFormLink =
   "https://docs.google.com/forms/d/e/1FAIpQLSeoUWA8LICvFhxhwiYBqWAjDxOZta1LgnPzkWtaWAoXQ1UESQ/viewform?usp=header";
-const printfulLink = "https://doyourownswing.printful.me/";
+export const printfulLink = "https://doyourownswing.printful.me/";
 
 // TODO: add alt text
 // maybe have each pic link to the particular listing?

--- a/web/src/components/home/subcomponents/merch/merch.jsx
+++ b/web/src/components/home/subcomponents/merch/merch.jsx
@@ -10,11 +10,10 @@ import merch4 from "@/assets/images/merch/im_shy_tee_unisex.webp";
 import merch5 from "@/assets/images/merch/dyos_stacked_unisex.webp";
 import merch6 from "@/assets/images/merch/heart_pocket_tee.webp";
 import { Space, Text } from "@/components/common/typography";
-import { HTML_IDS } from "../constants";
+import { HTML_IDS, MERCH_STORE_LINK } from "../constants";
 
 const googleFormLink =
   "https://docs.google.com/forms/d/e/1FAIpQLSeoUWA8LICvFhxhwiYBqWAjDxOZta1LgnPzkWtaWAoXQ1UESQ/viewform?usp=header";
-export const printfulLink = "https://doyourownswing.printful.me/";
 
 // TODO: add alt text
 // maybe have each pic link to the particular listing?
@@ -43,7 +42,7 @@ export default function Merch() {
             variant="contained"
             target="_blank"
             rel="noopener noreferrer"
-            href={printfulLink}
+            href={MERCH_STORE_LINK}
             size="large"
             sx={merchStyles.orderButton}
           >

--- a/web/src/components/not_found/not_found.jsx
+++ b/web/src/components/not_found/not_found.jsx
@@ -6,8 +6,8 @@ import { REGISTRATION_FORM_LINK, MERCH_STORE_LINK } from "@/common/constants";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
-// A map from URL segments that don't correspond to a link
-// to pages that the segment should redirect to
+// A map from pathnames that should redirect to an external site
+// to the external URL the path should redirect to
 const pageRedirects = {
   merch: MERCH_STORE_LINK,
   register: REGISTRATION_FORM_LINK,

--- a/web/src/components/not_found/not_found.jsx
+++ b/web/src/components/not_found/not_found.jsx
@@ -2,15 +2,14 @@ import { Box, Button, Container, Stack, Typography } from "@mui/material";
 import MimiPic from "@/assets/images/pets/mimi_1.jpg";
 import notFoundStyles from "./not_found.styles";
 import messages from "./messages";
-import { printfulLink } from "../home/subcomponents/merch/merch";
-import { REGISTRATION_FORM_LINK } from "@/common/constants";
+import { REGISTRATION_FORM_LINK, MERCH_STORE_LINK } from "@/common/constants";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 
 // A map from URL segments that don't correspond to a link
 // to pages that the segment should redirect to
 const pageRedirects = {
-  merch: printfulLink,
+  merch: MERCH_STORE_LINK,
   register: REGISTRATION_FORM_LINK,
 };
 

--- a/web/src/components/not_found/not_found.jsx
+++ b/web/src/components/not_found/not_found.jsx
@@ -2,8 +2,27 @@ import { Box, Button, Container, Stack, Typography } from "@mui/material";
 import MimiPic from "@/assets/images/pets/mimi_1.jpg";
 import notFoundStyles from "./not_found.styles";
 import messages from "./messages";
+import { printfulLink } from "../home/subcomponents/merch/merch";
+import { REGISTRATION_FORM_LINK } from "@/common/constants";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+// A map from URL segments that don't correspond to a link
+// to pages that the segment should redirect to
+const pageRedirects = {
+  merch: printfulLink,
+  register: REGISTRATION_FORM_LINK,
+};
 
 function NotFound() {
+  const location = useLocation();
+  useEffect(() => {
+    const pathWithoutSlashes = location.pathname.replaceAll("/", "");
+    if (pageRedirects[pathWithoutSlashes]) {
+      window.location.replace(pageRedirects[pathWithoutSlashes]);
+    }
+  }, [location.pathname]);
+
   return (
     <Box>
       <Container>

--- a/web/src/components/not_found/not_found.jsx
+++ b/web/src/components/not_found/not_found.jsx
@@ -13,15 +13,7 @@ const pageRedirects = {
   register: REGISTRATION_FORM_LINK,
 };
 
-function NotFound() {
-  const location = useLocation();
-  useEffect(() => {
-    const pathWithoutSlashes = location.pathname.replaceAll("/", "");
-    if (pageRedirects[pathWithoutSlashes]) {
-      window.location.replace(pageRedirects[pathWithoutSlashes]);
-    }
-  }, [location.pathname]);
-
+function NotFoundMessage() {
   return (
     <Box>
       <Container>
@@ -42,6 +34,24 @@ function NotFound() {
       </Container>
     </Box>
   );
+}
+
+/**
+ * A component for unknown routes that can also handle redirecting to
+ * external sites. If the path isn't in `pageRedirects`, displays a generic
+ * 404/not found message.
+ */
+function NotFound() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const pathWithoutSlashes = location.pathname.replaceAll("/", "");
+    if (pageRedirects[pathWithoutSlashes]) {
+      window.location.replace(pageRedirects[pathWithoutSlashes]);
+    }
+  }, [location.pathname]);
+
+  return <NotFoundMessage />;
 }
 
 export default NotFound;


### PR DESCRIPTION
Outfits the 404 page to check the pathname and potentially redirect to some external site, so that we can create short memorable URLs for DYOS-relevant links a la link shorteners or go/ links.

Did anyone ask for this: no. Is it cool / useful to be able to say "visit [dyos.dance/merch](https://dyos.dance/merch) for merch" or "visit [dyos.dance/register](https://dyos.dance/register) to fill out the waiver": maybe?

A possibly easier alternative could be a linktree.