### PR TITLE
Improvements to front desk sign-in page

### DIFF
--- a/server/apps_script/analytics.js
+++ b/server/apps_script/analytics.js
@@ -6,7 +6,7 @@ function dateTimeStringToDateString(dateTimeString) {
   let date = new Date(
     dateTime.getFullYear(),
     dateTime.getMonth(),
-    dateTime.getDate()
+    dateTime.getDate(),
   );
   return date.toDateString();
 }
@@ -76,16 +76,16 @@ function calculatePaymentStats(rawData) {
   return {
     totalAmountPaid: getTotalPayment(rawData),
     totalPaidByVenmo: getTotalPayment(
-      rawData.filter((r) => r.paymentMethod === "Venmo")
+      rawData.filter((r) => r.paymentMethod === "Venmo"),
     ),
     totalPaidByZelle: getTotalPayment(
-      rawData.filter((r) => r.paymentMethod === "Zelle")
+      rawData.filter((r) => r.paymentMethod === "Zelle"),
     ),
     totalPaidByPayPal: getTotalPayment(
-      rawData.filter((r) => r.paymentMethod === "PayPal")
+      rawData.filter((r) => r.paymentMethod === "PayPal"),
     ),
     totalPaidByCash: getTotalPayment(
-      rawData.filter((r) => r.paymentMethod === "Cash")
+      rawData.filter((r) => r.paymentMethod === "Cash"),
     ),
   };
 }
@@ -97,8 +97,13 @@ function calculateExemptionStats(rawData) {
       .length,
     numVolunteers: rawData.filter(
       (r) =>
+        // legacy values
         r.exemption === "30+ min Volunteer" ||
-        r.exemption === "15 min Volunteer"
+        r.exemption === "15 min Volunteer" ||
+        // current values
+        r.exemption === "15 min front desk volunteer" ||
+        r.exemption === "30+ min front desk volunteer" ||
+        r.exemption === "Volunteer lesson teacher",
     ).length,
   };
 }
@@ -126,6 +131,6 @@ function getAnalytics() {
 function doGet(e) {
   let jsonOutput = JSON.stringify(getAnalytics());
   return ContentService.createTextOutput(jsonOutput).setMimeType(
-    ContentService.MimeType.JSON
+    ContentService.MimeType.JSON,
   );
 }

--- a/web/src/components/admin/sign_in/constants.js
+++ b/web/src/components/admin/sign_in/constants.js
@@ -1,8 +1,9 @@
 export const EXEMPTION = {
   NONE: "N/A",
   SPONSOR: "Sponsor",
-  VOLUNTEER_15: "15 min Volunteer",
-  VOLUNTEER_30: "30+ min Volunteer",
+  VOLUNTEER_15: "15 min front desk volunteer",
+  VOLUNTEER_30: "30+ min front desk volunteer",
+  TEACHER: "Volunteer lesson teacher",
   ALL_STAR: "WSDC All-Star",
   BLACK_INDIGENOUS: "Black / Indigenous",
   PAID_BY_OTHER: "Paid for by someone else",
@@ -23,7 +24,7 @@ export const EVENTS = {
   L4: { id: "L4", displayName: "Level 4 (8:40pm)" },
   SOCIAL_ONLY: {
     id: "SOCIAL_ONLY",
-    displayName: "Social only / teaching only",
+    displayName: "Social only",
   },
 };
 

--- a/web/src/components/admin/sign_in/constants.js
+++ b/web/src/components/admin/sign_in/constants.js
@@ -21,7 +21,10 @@ export const EVENTS = {
   L2: { id: "L2", displayName: "Level 2 (7:30pm)" },
   L3: { id: "L3", displayName: "Level 3 (8:05pm)" },
   L4: { id: "L4", displayName: "Level 4 (8:40pm)" },
-  SOCIAL_ONLY: { id: "SOCIAL_ONLY", displayName: "Social only" },
+  SOCIAL_ONLY: {
+    id: "SOCIAL_ONLY",
+    displayName: "Social only / teaching only",
+  },
 };
 
 export const BASE_EVENTS_VALUE = {

--- a/web/src/components/admin/sign_in/constants.js
+++ b/web/src/components/admin/sign_in/constants.js
@@ -13,7 +13,6 @@ export const PAYMENT_OPTIONS = {
   CASH: "Cash",
   VENMO: "Venmo",
   ZELLE: "Zelle",
-  PAYPAL: "PayPal",
 };
 
 export const EVENTS = {

--- a/web/src/components/admin/sign_in/constants.js
+++ b/web/src/components/admin/sign_in/constants.js
@@ -13,6 +13,7 @@ export const PAYMENT_OPTIONS = {
   CASH: "Cash",
   VENMO: "Venmo",
   ZELLE: "Zelle",
+  PAYPAL: "PayPal",
 };
 
 export const EVENTS = {

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -24,6 +24,8 @@ const messages = {
     "Something is wrong, please try again. Get Jessee if it still won't work.",
   personsLabel: "Dancer(s)",
   whichClassesHeader: "Which classes do they plan to attend, if any?",
+  whichClassesExplainer:
+    "Only count students. In other words, if someone is teaching a class, don't count them as an attendee for that class.",
 };
 
 export default messages;

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -7,13 +7,14 @@ const messages = {
   submitSuccess: "Successfully checked in",
   submitError:
     "Something went wrong, please try again (and get Jessee if it still doesn't work)",
-  exemptionLabel: "Exemption",
+  exemptionLabel: "Payment exemption",
   maskLabel: "Purchased a mask (extra $1)",
-  additionalNotesLabel: "Additional notes",
+  additionalNotesLabel: "Notes",
   paymentMethodLabel: "Payment method",
   paymentHeader: "How are they paying?",
-  paymentAmountLabel:
-    "Full amount paid (include cost of mask if they bought one)",
+  paymentExplainer:
+    "Record the full amount they paid, including the cost of any mask(s) purchased. If they are not paying, record their exemption below to skip this section.",
+  paymentAmountLabel: "Payment amount",
   personsCheckinHeader: "Who is checking in?",
   personsCheckInExplainer:
     "If someone doesn't appear in this list, ask them to fill out the 2026 registration form. Once they're done, click Refresh.",

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -1,12 +1,12 @@
 const messages = {
   title: "DYOS Front Desk",
-  checkInTitle: "DYOS Check-In",
+  checkInTitle: "Check-in form",
   requiredFieldsUnset: "Fill required fields: ",
   submit: "Submit",
   clear: "Clear form",
   submitSuccess: "Successfully checked in",
   submitError:
-    "Something went wrong, please try again (and get Jessee if it still doesn't work)",
+    "Something went wrong, please try again. If it still doesn't work, please collect their information by hand.",
   exemptionLabel: "Payment exemption",
   maskLabel: "Purchased a mask (extra $1)",
   additionalNotesLabel: "Notes",
@@ -20,17 +20,17 @@ const messages = {
     "If someone doesn't appear in this list, ask them to fill out the 2026 registration form. Once they're done, click Refresh.",
   refreshOptions: "Refresh",
   refreshError:
-    "Something is wrong, please try again. If it still won't work, please collect this information some other way, and we'll enter it later.",
+    "Something is wrong, please try again. If it still doesn't work, please collect their information by hand.",
   personsLabel: "Dancer(s)",
   whichClassesHeader: "Which classes do they plan to attend, if any?",
   whichClassesExplainer:
-    "Only count students. In other words, if someone is teaching a class, don't count them as an attendee for that class.",
+    "Only count students. In other words, if someone is teaching a class, don't mark them as an attendee for that class.",
 
-  volunteerInstructionsHeader: "How to use this page",
+  volunteerInstructionsHeader: "How to run the front desk",
   volunteerInstructions: [
-    "Fill in the form below for every DYOS attendee",
-    "Collect cash payment, or confirm payment via app",
-    "Make sure everyone attending class or mask-required spaces has a mask (check with Riley if you're not sure about this week's mask policy)",
+    "For every DYOS attendee, fill in the form below",
+    "Confirm that they paid via Venmo or Zelle, or collect cash payment in the cash pouch",
+    "Make sure that everyone has a mask for classes (and, if masks are required tonight, for social dancing)",
   ],
   volunteerInstructionsThankYou:
     "Thank you for volunteering! Volunteers help keep DYOS running! 💜",

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -17,19 +17,19 @@ const messages = {
   paymentAmountLabel: "Payment amount",
   personsCheckinHeader: "Who is checking in?",
   personsCheckInExplainer:
-    "If someone doesn't appear in this list, ask them to fill out the 2026 registration form. Once they're done, click Refresh.",
+    "If someone doesn't appear in this list, ask them to fill out the 2026 registration form. Once they're done, click Refresh to update the list.",
   refreshOptions: "Refresh",
   refreshError:
     "Something is wrong, please try again. If it still doesn't work, please collect their information by hand.",
   personsLabel: "Dancer(s)",
   whichClassesHeader: "Which classes do they plan to attend, if any?",
   whichClassesExplainer:
-    "Only count students. In other words, if someone is teaching a class, don't mark them as an attendee for that class.",
+    "Only count students. In other words, if someone is teaching a class, don't mark them as attending that class.",
 
   volunteerInstructionsHeader: "How to run the front desk",
   volunteerInstructions: [
-    "For every DYOS attendee, fill in the form below",
-    "Confirm that they paid via Venmo or Zelle, or collect cash payment in the cash pouch",
+    "For every attendee, fill in the form below",
+    "Confirm that they paid via Venmo/Zelle/PayPal, or collect cash payment in the cash pouch",
     "Make sure that everyone has a mask for classes (and, if masks are required tonight, for social dancing)",
   ],
   volunteerInstructionsThankYou:

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -11,7 +11,6 @@ const messages = {
   maskLabel: "Purchased a mask (extra $1)",
   additionalNotesLabel: "Additional notes",
   paymentMethodLabel: "Payment method",
-  none: "None",
   paymentHeader: "How are they paying?",
   paymentAmountLabel:
     "Full amount paid (include cost of mask if they bought one)",

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -1,11 +1,6 @@
 const messages = {
-  title: "DYOS Front Desk Sign-In",
-  registrationHeader: "Have they filled out the registration form?",
-  fillOutThisForm: "If not, have them fill out this form: ",
-  registrationForm: "One-time registration form",
-  refreshAfterForm:
-    '. Then click the refresh button below, next to "Who is checking in"',
-  checkInTitle: "Check In",
+  title: "DYOS Front Desk",
+  checkInTitle: "DYOS Check-In",
   requiredFieldsUnset: "Fill required fields: ",
   submit: "Submit",
   clear: "Clear form",
@@ -13,19 +8,32 @@ const messages = {
   submitError:
     "Something went wrong, please try again (and get Jessee if it still doesn't work)",
   exemptionLabel: "Exemption",
-  maskLabel: "Purchasing Mask (extra $1)",
+  maskLabel: "Purchased a mask (extra $1)",
   additionalNotesLabel: "Additional notes",
   paymentMethodLabel: "Payment method",
   none: "None",
-  paymentAmountLabel: "Amount paid (include cost of mask if they bought one)",
-  personsCheckinHeader: "Who is checking in",
+  paymentHeader: "How are they paying?",
+  paymentAmountLabel:
+    "Full amount paid (include cost of mask if they bought one)",
+  personsCheckinHeader: "Who is checking in?",
+  personsCheckInExplainer:
+    "If someone doesn't appear in this list, ask them to fill out the 2026 registration form. Once they're done, click Refresh.",
   refreshOptions: "Refresh",
   refreshError:
-    "Something is wrong, please try again. Get Jessee if it still won't work.",
+    "Something is wrong, please try again. If it still won't work, please collect this information some other way, and we'll enter it later.",
   personsLabel: "Dancer(s)",
   whichClassesHeader: "Which classes do they plan to attend, if any?",
   whichClassesExplainer:
     "Only count students. In other words, if someone is teaching a class, don't count them as an attendee for that class.",
+
+  volunteerInstructionsHeader: "How to use this page",
+  volunteerInstructions: [
+    "Fill in the form below for every DYOS attendee",
+    "Collect cash payment, or confirm payment via app",
+    "Make sure everyone attending class or mask-required spaces has a mask (check with Riley if you're not sure about this week's mask policy)",
+  ],
+  volunteerInstructionsThankYou:
+    "Thank you for volunteering! Volunteers help keep DYOS running! 💜",
 };
 
 export default messages;

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -17,7 +17,7 @@ const messages = {
   additionalNotesLabel: "Additional notes",
   paymentMethodLabel: "Payment method",
   none: "None",
-  paymentAmountLabel: "Payment amount",
+  paymentAmountLabel: "Amount paid (include cost of mask if they bought one)",
   personsCheckinHeader: "Who is checking in",
   refreshOptions: "Refresh",
   refreshError:

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -1,5 +1,5 @@
 const messages = {
-  title: "Admin - sign in",
+  title: "DYOS Front Desk Sign-In",
   registrationHeader: "Have they filled out the registration form?",
   fillOutThisForm: "If not, have them fill out this form: ",
   registrationForm: "One-time registration form",

--- a/web/src/components/admin/sign_in/sign_in.jsx
+++ b/web/src/components/admin/sign_in/sign_in.jsx
@@ -145,10 +145,10 @@ function SignIn() {
                 <Typography sx={signInStyles.formHeader}>
                   {messages.paymentHeader}
                 </Typography>
-                <ExemptionInput
-                  value={exemption}
-                  onSelectExemption={onSelectExemption}
-                />
+
+                <Typography sx={signInStyles.formExplainer}>
+                  {messages.paymentExplainer}
+                </Typography>
 
                 <PaymentInput
                   paymentMethodValue={paymentMethod}
@@ -158,16 +158,27 @@ function SignIn() {
                   required={isPaymentRequired(exemption, buyingMask)}
                 />
 
-                <MaskInput
-                  checked={buyingMask}
-                  onMaskPurchaseChange={onMaskPurchaseChange}
-                />
+                <Box sx={signInStyles.section}>
+                  <Typography sx={signInStyles.formHeader}>
+                    Additional information
+                  </Typography>
 
-                <NotesInput
-                  value={additionalNotes}
-                  onSetAdditionalNotes={onSetAdditionalNotes}
-                  required={exemption === EXEMPTION.OTHER}
-                />
+                  <ExemptionInput
+                    value={exemption}
+                    onSelectExemption={onSelectExemption}
+                  />
+
+                  <MaskInput
+                    checked={buyingMask}
+                    onMaskPurchaseChange={onMaskPurchaseChange}
+                  />
+
+                  <NotesInput
+                    value={additionalNotes}
+                    onSetAdditionalNotes={onSetAdditionalNotes}
+                    required={exemption === EXEMPTION.OTHER}
+                  />
+                </Box>
               </Box>
               <WhichEvents
                 value={eventsAttending}

--- a/web/src/components/admin/sign_in/sign_in.jsx
+++ b/web/src/components/admin/sign_in/sign_in.jsx
@@ -183,6 +183,7 @@ function SignIn() {
               <WhichEvents
                 value={eventsAttending}
                 onSetEventsAttendingChange={setEventsAttending}
+                required={exemption !== EXEMPTION.TEACHER}
               />
             </Stack>
             <Box sx={signInStyles.inputContainer}>

--- a/web/src/components/admin/sign_in/sign_in.jsx
+++ b/web/src/components/admin/sign_in/sign_in.jsx
@@ -112,7 +112,8 @@ function SignIn() {
     buyingMask,
     paymentAmount,
     paymentMethod,
-    eventsAttending
+    eventsAttending,
+    additionalNotes,
   );
   let formValid = unfilledRequiredFields.length === 0;
 

--- a/web/src/components/admin/sign_in/sign_in.jsx
+++ b/web/src/components/admin/sign_in/sign_in.jsx
@@ -142,7 +142,9 @@ function SignIn() {
               sx={signInStyles.inputSection}
             >
               <Box sx={signInStyles.formLeft}>
-                <Typography sx={signInStyles.formHeader}>Payment</Typography>
+                <Typography sx={signInStyles.formHeader}>
+                  {messages.paymentHeader}
+                </Typography>
                 <ExemptionInput
                   value={exemption}
                   onSelectExemption={onSelectExemption}

--- a/web/src/components/admin/sign_in/sign_in.jsx
+++ b/web/src/components/admin/sign_in/sign_in.jsx
@@ -1,10 +1,8 @@
 import { Box, Button, Container, Stack, Typography } from "@mui/material";
-import DyosLink from "@/components/common/link";
 import { useState } from "react";
 import signInStyles from "./sign_in.styles";
 import SignInService from "./sign_in_service";
 import { isPaymentRequired, validateForm } from "./utils";
-import { REGISTRATION_FORM_LINK } from "@/common/constants";
 import Callout from "@/components/common/callout";
 import {
   EXEMPTION,
@@ -12,6 +10,7 @@ import {
   DATA_STATE,
   BASE_EVENTS_VALUE,
 } from "@/components/admin/sign_in/constants";
+import { VolunteerInstructions } from "@/components/admin/sign_in/subcomponents/volunteer_instructions";
 import PersonInput from "@/components/admin/sign_in/subcomponents/person_input";
 import ExemptionInput from "@/components/admin/sign_in/subcomponents/exemption_input";
 import PaymentInput from "@/components/admin/sign_in/subcomponents/payment_input";
@@ -124,22 +123,9 @@ function SignIn() {
           <Typography variant="h4" sx={signInStyles.title}>
             {messages.title}
           </Typography>
-          <Box sx={signInStyles.section}>
-            <Typography variant="h5" sx={signInStyles.sectionHeader}>
-              {messages.registrationHeader}
-            </Typography>
-            <Typography display="inline">{messages.fillOutThisForm}</Typography>
-            <DyosLink
-              href={REGISTRATION_FORM_LINK}
-              openInNewTab
-              fontWeight="bold"
-            >
-              {messages.registrationForm}
-            </DyosLink>
-            <Typography display="inline">
-              {messages.refreshAfterForm}
-            </Typography>
-          </Box>
+
+          <VolunteerInstructions />
+
           <Box sx={signInStyles.section}>
             <Typography variant="h5" sx={signInStyles.sectionHeader}>
               {messages.checkInTitle}

--- a/web/src/components/admin/sign_in/sign_in.styles.js
+++ b/web/src/components/admin/sign_in/sign_in.styles.js
@@ -26,10 +26,13 @@ const signInStyles = {
     textAlign: "center",
   },
   section: {
-    paddingTop: "4rem",
+    paddingTop: "3rem",
   },
   sectionHeader: {
     ...baseHeaderText,
+  },
+  volunteerInstructionsContainer: {
+    marginTop: "1rem",
   },
   inputSection: {
     paddingBottom: "2rem",

--- a/web/src/components/admin/sign_in/sign_in.styles.js
+++ b/web/src/components/admin/sign_in/sign_in.styles.js
@@ -55,6 +55,9 @@ const signInStyles = {
     ...baseHeaderText,
     paddingBottom: "1rem",
   },
+  formExplainer: {
+    paddingBottom: "1rem",
+  },
   personSectionHeaderText: {
     ...baseHeaderText,
     paddingTop: "1rem",

--- a/web/src/components/admin/sign_in/sign_in.styles.js
+++ b/web/src/components/admin/sign_in/sign_in.styles.js
@@ -45,11 +45,11 @@ const signInStyles = {
   },
   paymentContainer: {
     display: "flex",
-    flexDirection: { xs: "column", md: "row" },
+    flexDirection: "column",
     gap: "2rem",
   },
   paymentAmount: {
-    width: { xs: "min(80vw, 20rem)", md: "unset" },
+    width: { xs: "min(80vw, 20rem)", md: "25rem" },
   },
   formHeader: {
     ...baseHeaderText,

--- a/web/src/components/admin/sign_in/sign_in.styles.js
+++ b/web/src/components/admin/sign_in/sign_in.styles.js
@@ -47,13 +47,13 @@ const signInStyles = {
     width: "min(80vw, 36rem)",
   },
   paymentContainer: {
-    display: "flex",
-    flexDirection: { xs: "column", md: "row" },
-    alignItems: "flex-end",
-    gap: "2rem",
+    display: "grid",
+    alignItems: "end",
+    gridTemplateColumns: "2.5fr 1fr",
+    paddingRight: "2rem",
   },
   paymentAmount: {
-    width: { xs: "min(80vw, 20rem)", md: "unset" },
+    width: "unset",
   },
   formHeader: {
     ...baseHeaderText,

--- a/web/src/components/admin/sign_in/sign_in.styles.js
+++ b/web/src/components/admin/sign_in/sign_in.styles.js
@@ -48,11 +48,12 @@ const signInStyles = {
   },
   paymentContainer: {
     display: "flex",
-    flexDirection: "column",
+    flexDirection: { xs: "column", md: "row" },
+    alignItems: "flex-end",
     gap: "2rem",
   },
   paymentAmount: {
-    width: { xs: "min(80vw, 20rem)", md: "25rem" },
+    width: { xs: "min(80vw, 20rem)", md: "unset" },
   },
   formHeader: {
     ...baseHeaderText,

--- a/web/src/components/admin/sign_in/subcomponents/exemption_input.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/exemption_input.jsx
@@ -19,7 +19,7 @@ function ExemptionInput(props) {
         <Select
           labelId="exemption-label"
           value={props.value}
-          label="Exemption"
+          label={messages.exemptionLabel}
           onChange={props.onSelectExemption}
           sx={signInStyles.input}
         >

--- a/web/src/components/admin/sign_in/subcomponents/notes_input.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/notes_input.jsx
@@ -16,7 +16,7 @@ function NotesInput(props) {
           label={messages.additionalNotesLabel}
           multiline
           sx={signInStyles.additionalNotesInput}
-          rows={4}
+          rows={2}
           value={props.value}
           onChange={props.onSetAdditionalNotes}
         />

--- a/web/src/components/admin/sign_in/subcomponents/payment_input.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/payment_input.jsx
@@ -1,11 +1,13 @@
 import {
   Box,
   FormControl,
+  FormControlLabel,
+  FormLabel,
   InputAdornment,
   InputLabel,
-  MenuItem,
   OutlinedInput,
-  Select,
+  Radio,
+  RadioGroup,
 } from "@mui/material";
 import signInStyles from "../sign_in.styles";
 import { PAYMENT_OPTIONS } from "@/components/admin/sign_in/constants";
@@ -19,23 +21,23 @@ function PaymentInput(props) {
     <Box sx={signInStyles.inputContainer}>
       <Box sx={signInStyles.paymentContainer}>
         <FormControl required={required}>
-          <InputLabel id="payment-method-label">
+          <FormLabel id="payment-method-label">
             {messages.paymentMethodLabel}
-          </InputLabel>
-          <Select
-            labelId="payment-method-label"
+          </FormLabel>
+
+          <RadioGroup
+            row
+            aria-labelledby="payment-method-label"
+            name="payment-method"
             value={props.paymentMethodValue}
-            label="Payment method"
             onChange={props.onSelectPaymentMethod}
-            sx={signInStyles.input}
           >
-            <MenuItem value="">
-              <em>{messages.none}</em>
-            </MenuItem>
             {Object.values(PAYMENT_OPTIONS).map((o) => (
-              <MenuItem value={o}>{o}</MenuItem>
+              <FormControlLabel key={o} value={o} control={<Radio />} label={o}>
+                {o}
+              </FormControlLabel>
             ))}
-          </Select>
+          </RadioGroup>
         </FormControl>
 
         <FormControl required={required}>

--- a/web/src/components/admin/sign_in/subcomponents/person_input.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/person_input.jsx
@@ -80,6 +80,9 @@ function PersonInput(props) {
         )}
       </Box>
       {hasError && <Typography>{messages.refreshError}</Typography>}
+      <Typography sx={signInStyles.formExplainer}>
+        {messages.personsCheckInExplainer}
+      </Typography>
       <Autocomplete
         multiple
         options={data}

--- a/web/src/components/admin/sign_in/subcomponents/volunteer_instructions.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/volunteer_instructions.jsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from "@mui/material";
+import DyosLink from "@/components/common/link";
+import signInStyles from "./sign_in.styles";
+import { REGISTRATION_FORM_LINK } from "@/common/constants";
+import messages from "@/components/admin/sign_in/messages";
+
+export function VolunteerInstructions() {
+  return (
+    <Box sx={signInStyles.section}>
+      <Typography variant="h5" sx={signInStyles.sectionHeader}>
+        {messages.registrationHeader}
+      </Typography>
+      <Typography display="inline">{messages.fillOutThisForm}</Typography>
+      <DyosLink href={REGISTRATION_FORM_LINK} openInNewTab fontWeight="bold">
+        {messages.registrationForm}
+      </DyosLink>
+      <Typography display="inline">{messages.refreshAfterForm}</Typography>
+    </Box>
+  );
+}

--- a/web/src/components/admin/sign_in/subcomponents/volunteer_instructions.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/volunteer_instructions.jsx
@@ -1,20 +1,23 @@
 import { Box, Typography } from "@mui/material";
-import DyosLink from "@/components/common/link";
-import signInStyles from "./sign_in.styles";
-import { REGISTRATION_FORM_LINK } from "@/common/constants";
+import signInStyles from "../sign_in.styles";
 import messages from "@/components/admin/sign_in/messages";
 
 export function VolunteerInstructions() {
   return (
     <Box sx={signInStyles.section}>
       <Typography variant="h5" sx={signInStyles.sectionHeader}>
-        {messages.registrationHeader}
+        {messages.volunteerInstructionsHeader}
       </Typography>
-      <Typography display="inline">{messages.fillOutThisForm}</Typography>
-      <DyosLink href={REGISTRATION_FORM_LINK} openInNewTab fontWeight="bold">
-        {messages.registrationForm}
-      </DyosLink>
-      <Typography display="inline">{messages.refreshAfterForm}</Typography>
+      <Box sx={signInStyles.volunteerInstructionsContainer}>
+        <ul>
+          {messages.volunteerInstructions.map((text) => (
+            <li key={text}>
+              <Typography>{text}</Typography>
+            </li>
+          ))}
+        </ul>
+        <Typography>{messages.volunteerInstructionsThankYou}</Typography>
+      </Box>
     </Box>
   );
 }

--- a/web/src/components/admin/sign_in/subcomponents/which_events_input.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/which_events_input.jsx
@@ -32,7 +32,11 @@ function WhichEvents(props) {
 
   return (
     <Box>
-      <FormControl component="fieldset" variant="standard" required>
+      <FormControl
+        component="fieldset"
+        variant="standard"
+        required={props.required}
+      >
         <FormLabel component="legend" sx={signInStyles.formHeader}>
           {messages.whichClassesHeader}
         </FormLabel>

--- a/web/src/components/admin/sign_in/subcomponents/which_events_input.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/which_events_input.jsx
@@ -31,7 +31,7 @@ function WhichEvents(props) {
   };
 
   return (
-    <Box sx={signInStyles.inputContainer}>
+    <Box>
       <FormControl component="fieldset" variant="standard" required>
         <FormLabel component="legend" sx={signInStyles.formHeader}>
           {messages.whichClassesHeader}

--- a/web/src/components/admin/sign_in/subcomponents/which_events_input.jsx
+++ b/web/src/components/admin/sign_in/subcomponents/which_events_input.jsx
@@ -5,6 +5,7 @@ import {
   FormControlLabel,
   FormGroup,
   FormLabel,
+  Typography,
 } from "@mui/material";
 import signInStyles from "../sign_in.styles";
 import { EVENTS } from "@/components/admin/sign_in/constants";
@@ -35,6 +36,11 @@ function WhichEvents(props) {
         <FormLabel component="legend" sx={signInStyles.formHeader}>
           {messages.whichClassesHeader}
         </FormLabel>
+        <Box sx={signInStyles.formExplainer}>
+          <Typography display="inline">
+            {messages.whichClassesExplainer}
+          </Typography>
+        </Box>
         <FormGroup sx={signInStyles.eventsCheckboxGroup}>
           {Object.values(EVENTS).map((v) => {
             return (

--- a/web/src/components/admin/sign_in/utils.js
+++ b/web/src/components/admin/sign_in/utils.js
@@ -29,7 +29,7 @@ function validateMoneyValue(value) {
 
     let number = parseFloat(value);
 
-    return number > 0;
+    return number >= 0;
   } catch {
     return false;
   }
@@ -49,7 +49,7 @@ function validateForm(
   buyingMask,
   paymentAmount,
   paymentMethod,
-  eventsAttending
+  eventsAttending,
 ) {
   let unfilledRequiredFields = [];
 

--- a/web/src/components/admin/sign_in/utils.js
+++ b/web/src/components/admin/sign_in/utils.js
@@ -29,7 +29,7 @@ function validateMoneyValue(value) {
 
     let number = parseFloat(value);
 
-    return number >= 0;
+    return number > 0;
   } catch {
     return false;
   }

--- a/web/src/components/admin/sign_in/utils.js
+++ b/web/src/components/admin/sign_in/utils.js
@@ -69,7 +69,10 @@ function validateForm(
     unfilledRequiredFields.push("Additional notes");
   }
 
-  if (!Object.values(eventsAttending).some((e) => e)) {
+  if (
+    exemption !== EXEMPTION.TEACHER &&
+    !Object.values(eventsAttending).some((e) => e)
+  ) {
     unfilledRequiredFields.push("Classes attending");
   }
 

--- a/web/src/components/admin/sign_in/utils.js
+++ b/web/src/components/admin/sign_in/utils.js
@@ -50,6 +50,7 @@ function validateForm(
   paymentAmount,
   paymentMethod,
   eventsAttending,
+  additionalNotes,
 ) {
   let unfilledRequiredFields = [];
 
@@ -64,7 +65,7 @@ function validateForm(
     if (!validateMoneyValue(paymentAmount)) {
       unfilledRequiredFields.push("Payment amount");
     }
-  } else if (exemption === EXEMPTION.OTHER) {
+  } else if (exemption === EXEMPTION.OTHER && additionalNotes === "") {
     unfilledRequiredFields.push("Additional notes");
   }
 

--- a/web/src/page_registry.jsx
+++ b/web/src/page_registry.jsx
@@ -28,34 +28,35 @@ const pageRegistry = [
   new PageRegistrationInfo(
     pages.Schedule,
     FeatureFlags.showScheduleTab,
-    <Schedule />
+    <Schedule />,
   ),
   new PageRegistrationInfo(pages.About, FeatureFlags.showAboutTab, <About />),
   new PageRegistrationInfo(
     pages.Health,
     FeatureFlags.showHealthTab,
-    <Health />
+    <Health />,
   ),
   new PageRegistrationInfo(
     pages.Code,
     FeatureFlags.showCodeOfConductTab,
-    <CodeOfConduct />
+    <CodeOfConduct />,
   ),
   new PageRegistrationInfo(
     pages.Contact,
     FeatureFlags.showContactTab,
-    <Contact />
+    <Contact />,
   ),
   new PageRegistrationInfo(
     pages.StartHere,
     FeatureFlags.showStartHerePage,
-    <StartHere />
+    <StartHere />,
   ),
   new PageRegistrationInfo(pages.Blog, FeatureFlags.showBlog, <Blog />),
   new PageRegistrationInfo(pages.SignIn, true, <SignIn />, {
     navBarOverrides: {
       showNavBar: false,
     },
+    showFooter: false,
   }),
   new PageRegistrationInfo(pages.Ipad, true, <Ipad />, {
     navBarOverrides: {


### PR DESCRIPTION
A variety of small improvements to the front desk sign-in page:
- Bugfixes:
   - form validation now correctly checks the notes section when "other" payment exemption is selected
   - ~~form allows user to specify payment amount of $0 (and continues to disallow the empty string)~~
- Adds/clarifies instructions for most fields. This makes the form overall more verbose, but hopefully this has two benefits:
   - Makes it easier for new volunteers to onboard to the page
   - Increases consistency among regular volunteers who might not be sure about edge cases (I only learned today that I was supposed to be including the mask $1 in the payment amount! 😅 ) 
- Makes the payment method input a radio group (~50 fewer clicks per night 😛 )

Closes #179 (I no longer think we should optimistically mark the form as submitted) 

Before and after images: 

<img width="750" alt="before" src="https://github.com/user-attachments/assets/c6cd037c-6ba1-44c4-a66e-00e1c1fb17f8" />

<img width="750" alt="after" src="https://github.com/user-attachments/assets/cb5d4ed2-948b-4107-9ff4-f77f09c73c48" />