### PR TITLE
Add page titles

### DIFF
--- a/web/src/common/hooks.js
+++ b/web/src/common/hooks.js
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+/**
+ * Sets the page's title. Or, if a title wasn't passed in,
+ * resets the page's title to the default.
+ *
+ * This hook should be called once in every top-level component.
+ */
+export function useTitle(title) {
+  useEffect(() => {
+    if (title) {
+      document.title = `${title} | Do Your Own Swing`;
+    } else {
+      document.title = "Do Your Own Swing";
+    }
+  }, [title]);
+}

--- a/web/src/common/hooks.js
+++ b/web/src/common/hooks.js
@@ -8,10 +8,8 @@ import { useEffect } from "react";
  */
 export function useTitle(title) {
   useEffect(() => {
-    if (title) {
-      document.title = `${title} | Do Your Own Swing`;
-    } else {
-      document.title = "Do Your Own Swing";
-    }
+    document.title = title
+      ? `${title} | Do Your Own Swing`
+      : "Do Your Own Swing";
   }, [title]);
 }

--- a/web/src/components/about/about.jsx
+++ b/web/src/components/about/about.jsx
@@ -156,7 +156,7 @@ function RileyBio() {
 }
 
 function About() {
-  useTitle("About");
+  useTitle("About Us");
 
   return (
     <Box>

--- a/web/src/components/about/about.jsx
+++ b/web/src/components/about/about.jsx
@@ -7,6 +7,7 @@ import DyosLink from "@/components/common/link";
 import { styled } from "@mui/material/styles";
 import { useState } from "react";
 import PurpleLogo from "@/assets/svgs/purple-logo.svg";
+import { useTitle } from "@/common/hooks";
 
 const Paragraph = styled("p")(({ _ }) => aboutStyles.paragraph);
 
@@ -155,6 +156,8 @@ function RileyBio() {
 }
 
 function About() {
+  useTitle("About");
+
   return (
     <Box>
       <Splash />

--- a/web/src/components/admin/analytics/analytics.jsx
+++ b/web/src/components/admin/analytics/analytics.jsx
@@ -5,6 +5,8 @@ import Payment from "@/components/admin/analytics/payment";
 import { Box, Container, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
 
+import { useTitle } from "@/common/hooks";
+
 function Loading() {
   return (
     <Box sx={{ height: "100vh" }}>
@@ -25,6 +27,8 @@ function Stats(props) {
 }
 
 function Analytics() {
+  useTitle("Cool Stats");
+
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
 

--- a/web/src/components/admin/ipad/ipad.jsx
+++ b/web/src/components/admin/ipad/ipad.jsx
@@ -11,6 +11,8 @@ import {
 } from "@/common/constants";
 import QRCode from "react-qr-code";
 
+import { useTitle } from "@/common/hooks";
+
 const TABS = {
   REGISTRATION_FORM: "Registration Form",
   CLASSES: "Classes",
@@ -46,6 +48,8 @@ function EmbeddedRegistrationForm() {
 }
 
 function Ipad() {
+  useTitle();
+
   const [selectedTab, setSelectedTab] = useState(TABS.REGISTRATION_FORM);
 
   const onTabChange = (_, newValue) => {

--- a/web/src/components/code_of_conduct/code_of_conduct.jsx
+++ b/web/src/components/code_of_conduct/code_of_conduct.jsx
@@ -13,6 +13,7 @@ import DyosLink from "@/components/common/link";
 import Callout from "@/components/common/callout";
 import { forwardRef, useRef } from "react";
 import { INCIDENT_REPORT_FORM } from "@/common/constants";
+import { useTitle } from "@/common/hooks";
 
 function TitleSection(props) {
   return (
@@ -198,6 +199,8 @@ const ResponseSection = forwardRef(function Response(_, ref) {
 });
 
 function CodeOfConduct() {
+  useTitle("Code of Conduct");
+
   const missionStatementRef = useRef(null);
   const agreementsRef = useRef(null);
   const praxisRef = useRef(null);

--- a/web/src/components/contact/contact.jsx
+++ b/web/src/components/contact/contact.jsx
@@ -21,6 +21,7 @@ import {
 } from "@/common/constants";
 import messages from "./messages";
 import "./contact.css";
+import { useTitle } from "@/common/hooks";
 
 function SocialsButton(props) {
   return (
@@ -37,6 +38,8 @@ function SocialsButton(props) {
 }
 
 function Contact() {
+  useTitle("Contact");
+
   const [copiedSnackbarMessage, setCopiedSnackbarMessage] = useState("");
   const [copiedSnackbarOpen, setCopiedSnackbarOpen] = useState(false);
 

--- a/web/src/components/home/home.jsx
+++ b/web/src/components/home/home.jsx
@@ -6,8 +6,10 @@ import WhoWeAre from "./subcomponents/who_we_are/who_we_are";
 import FeatureFlags from "@/infra/feature_flags";
 import Merch from "./subcomponents/merch/merch";
 import UpcomingEventsV2 from "@/components/home/subcomponents/upcoming_events_v2/upcoming_events_v2";
+import { useTitle } from "@/common/hooks";
 
 export default function Home() {
+  useTitle();
   return (
     <Box>
       <Hero />

--- a/web/src/components/links/links.jsx
+++ b/web/src/components/links/links.jsx
@@ -43,6 +43,8 @@ import ZelleLogoIcon from "@/assets/images/payment_logos/zelle-logo-icon.png";
 import { useState } from "react";
 import messages from "@/components/links/messages";
 
+import { useTitle } from "@/common/hooks";
+
 function Header() {
   return (
     <Box sx={linksStyles.topContainer}>
@@ -267,6 +269,8 @@ function LinksCard() {
 }
 
 function Links() {
+  useTitle();
+
   return (
     <Box sx={linksStyles.container}>
       <Box sx={linksStyles.contentContainer}>

--- a/web/src/components/not_found/not_found.jsx
+++ b/web/src/components/not_found/not_found.jsx
@@ -5,6 +5,7 @@ import messages from "./messages";
 import { REGISTRATION_FORM_LINK, MERCH_STORE_LINK } from "@/common/constants";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { useTitle } from "@/common/hooks";
 
 // A map from pathnames that should redirect to an external site
 // to the external URL the path should redirect to
@@ -48,6 +49,8 @@ function NotFoundMessage() {
  * 404/not found message.
  */
 function NotFound() {
+  useTitle();
+
   const location = useLocation();
 
   useEffect(() => {

--- a/web/src/components/not_found/not_found.jsx
+++ b/web/src/components/not_found/not_found.jsx
@@ -49,7 +49,7 @@ function NotFoundMessage() {
  * 404/not found message.
  */
 function NotFound() {
-  useTitle();
+  useTitle("Page Not Found");
 
   const location = useLocation();
 

--- a/web/src/components/schedule/schedule.jsx
+++ b/web/src/components/schedule/schedule.jsx
@@ -7,8 +7,11 @@ import Volunteer from "./subcomponents/volunteer/volunteer";
 import scheduleStyles from "./schedule.styles";
 import { useRef } from "react";
 import Privates from "./subcomponents/privates/privates";
+import { useTitle } from "@/common/hooks";
 
 function Schedule() {
+  useTitle("West Coast Swing Classes");
+
   const suggestedPricingRef = useRef(null);
   const volunteerRef = useRef(null);
 

--- a/web/src/components/schedule/schedule.jsx
+++ b/web/src/components/schedule/schedule.jsx
@@ -10,7 +10,7 @@ import Privates from "./subcomponents/privates/privates";
 import { useTitle } from "@/common/hooks";
 
 function Schedule() {
-  useTitle("West Coast Swing Classes");
+  useTitle("Thursday West Coast Swing Classes");
 
   const suggestedPricingRef = useRef(null);
   const volunteerRef = useRef(null);

--- a/web/src/components/start_here/start_here.jsx
+++ b/web/src/components/start_here/start_here.jsx
@@ -5,8 +5,11 @@ import BeforeTheEvent from "./subcomponents/before_the_event";
 import WhenYouArrive from "./subcomponents/when_you_arrive";
 import Faqs from "./subcomponents/faqs";
 import WelcomeImage from "@/assets/images/jon-sherwin.png";
+import { useTitle } from "@/common/hooks";
 
 function StartHere() {
+  useTitle("Newcomer Guide");
+
   return (
     <Box>
       <Box sx={startHereStyles.container}>


### PR DESCRIPTION
Tiny enhancement: Adds page titles, using a new hook for setting the title of a page, e.g. "West Coast Swing Classes | Do Your Own Swing". The aim is for pages to show up in search engine results for more terms without affecting the content of the page, but I don't actually know if it will work.

Also right now the copy is hard-coded in each component, which seems not ideal.