### PR TITLE
Add exemption and special instructions for spectators

### DIFF
--- a/web/src/components/admin/sign_in/constants.js
+++ b/web/src/components/admin/sign_in/constants.js
@@ -7,6 +7,7 @@ export const EXEMPTION = {
   ALL_STAR: "WSDC All-Star",
   BLACK_INDIGENOUS: "Black / Indigenous",
   PAID_BY_OTHER: "Paid for by someone else",
+  SPECTATOR: "Spectator (not dancing)",
   OTHER: "Other",
 };
 

--- a/web/src/components/admin/sign_in/messages.js
+++ b/web/src/components/admin/sign_in/messages.js
@@ -10,6 +10,8 @@ const messages = {
   resubmitPrompt:
     "Something went wrong, please try to resubmit this person's data. If it still doesn't work, please copy this information down by hand.",
   exemptionLabel: "Payment exemption",
+  spectatorInfo:
+    "You can find single-use yellow wristbands for spectators in the cash pouch.",
   maskLabel: "Purchased a mask (extra $1)",
   additionalNotesLabel: "Notes",
   paymentMethodLabel: "Payment method",

--- a/web/src/components/admin/sign_in/sign_in.jsx
+++ b/web/src/components/admin/sign_in/sign_in.jsx
@@ -102,6 +102,11 @@ function SignIn() {
 
   const onSelectExemption = (event) => {
     setExemption(event.target.value);
+
+    // If the person is a spectator, unselect any selected events
+    if (event.target.value === EXEMPTION.SPECTATOR) {
+      setEventsAttending(BASE_EVENTS_VALUE);
+    }
   };
 
   const onMaskPurchaseChange = (event) => {
@@ -183,6 +188,10 @@ function SignIn() {
                     onSelectExemption={onSelectExemption}
                   />
 
+                  {exemption === EXEMPTION.SPECTATOR && (
+                    <Typography>{messages.spectatorInfo}</Typography>
+                  )}
+
                   <MaskInput
                     checked={buyingMask}
                     onMaskPurchaseChange={onMaskPurchaseChange}
@@ -195,11 +204,17 @@ function SignIn() {
                   />
                 </Box>
               </Box>
-              <WhichEvents
-                value={eventsAttending}
-                onSetEventsAttendingChange={setEventsAttending}
-                required={exemption !== EXEMPTION.TEACHER}
-              />
+              {exemption !== EXEMPTION.SPECTATOR && (
+                <WhichEvents
+                  value={eventsAttending}
+                  onSetEventsAttendingChange={setEventsAttending}
+                  required={
+                    ![EXEMPTION.TEACHER, EXEMPTION.SPECTATOR].includes(
+                      exemption,
+                    )
+                  }
+                />
+              )}
             </Stack>
             <Box sx={signInStyles.inputContainer}>
               {!formValid && (

--- a/web/src/components/admin/sign_in/utils.js
+++ b/web/src/components/admin/sign_in/utils.js
@@ -70,7 +70,7 @@ function validateForm(
   }
 
   if (
-    exemption !== EXEMPTION.TEACHER &&
+    ![EXEMPTION.TEACHER, EXEMPTION.SPECTATOR].includes(exemption) &&
     !Object.values(eventsAttending).some((e) => e)
   ) {
     unfilledRequiredFields.push("Classes attending");


### PR DESCRIPTION
Adds a new dropdown entry for spectators. My main motivation is because I hadn't known what the yellow wristbands are for - so if the spectator exemption is selected, shows special instructions about the wristbands and prevents the user from selecting any events for this person. (I think this would be most accurate, since they're not dancing? If you feel strongly otherwise, I can change it.)

Here's how it looks:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/7a9d7d50-8730-4586-82b0-a0af8959cb07" />
