### PR TITLE
Some more charts

### DIFF
--- a/web/src/common/theme.jsx
+++ b/web/src/common/theme.jsx
@@ -187,10 +187,10 @@ const theme = responsiveFontSizes(
       },
       charts: {
         l1: basePalette.purple300,
-        l2: basePalette.purple400,
-        l3: basePalette.purple500,
-        l4: basePalette.purple600,
-        socialOnly: basePalette.purple700,
+        l2: basePalette.purple500,
+        l3: basePalette.purple600,
+        l4: basePalette.purple900,
+        socialOnly: basePalette.blue300,
         cash: "green",
         venmo: "#008cff",
         paypal: "#002b87",
@@ -234,7 +234,7 @@ const theme = responsiveFontSizes(
         fontFamily: "Poppins",
       },
     },
-  })
+  }),
 );
 
 export default theme;

--- a/web/src/components/admin/analytics/attendance.jsx
+++ b/web/src/components/admin/analytics/attendance.jsx
@@ -189,19 +189,31 @@ function ClassAttendance(props) {
           <Typography variant="h6" sx={analyticsStyles.chartTitle}>
             Class attendance
           </Typography>
+          <Typography variant="subtitle" sx={analyticsStyles.chartSubtitle}>
+            Click a legend item to show/hide that class
+          </Typography>
         </Box>
-        <BarChart
+        <LineChart
           height={300}
           series={[
-            { data: l1, label: "L1", id: "l1" },
-            { data: l2, label: "L2", id: "l2" },
-            { data: l3, label: "L3", id: "l3" },
-            { data: l4, label: "L4", id: "l4" },
-            { data: socialOnly, label: "Social Only", id: "so" },
+            { data: l1, label: "L1", showMark: false },
+            { data: l2, label: "L2", showMark: false },
+            { data: l3, label: "L3", showMark: false },
+            { data: l4, label: "L4", showMark: false },
+            {
+              data: socialOnly,
+              label: "Social Only",
+              showMark: false,
+            },
           ]}
           colors={colors}
-          xAxis={[{ data: xLabels, height: 28 }]}
+          xAxis={[{ scaleType: "point", data: xLabels, height: 28 }]}
           yAxis={[{ width: 50 }]}
+          slotProps={{
+            legend: {
+              toggleVisibilityOnClick: true,
+            },
+          }}
         />
         <SummaryStats
           dataArrays={[l1, l2, l3, l4, socialOnly]}

--- a/web/src/components/admin/analytics/attendance.jsx
+++ b/web/src/components/admin/analytics/attendance.jsx
@@ -16,8 +16,7 @@ const MAX_HISTOGRAM_SECTIONS = 10;
 /**
  * Given dataArrays (an array of numeric arrays),
  * dates (an array of strings with the same length as an array in data),
- * labels (one for each array in data),
- * and colors (optional)
+ * and labels (one for each array in data),
  * displays summary statistics for each array in the data.
  */
 function SummaryStats({ dataArrays, dates, labels }) {
@@ -187,10 +186,10 @@ function ClassAttendance(props) {
       <DyosCard>
         <Box sx={analyticsStyles.chartTitleContainer}>
           <Typography variant="h6" sx={analyticsStyles.chartTitle}>
-            Class attendance
+            Class attendance (# of people)
           </Typography>
           <Typography variant="subtitle" sx={analyticsStyles.chartSubtitle}>
-            Click a legend item to show/hide that class
+            Click a legend item to show/hide that line
           </Typography>
         </Box>
         <LineChart
@@ -225,6 +224,83 @@ function ClassAttendance(props) {
   );
 }
 
+function PercentClassAttendance(props) {
+  let data = props.data.weeklyStats;
+
+  const xLabels = data.map((d) => prettyPrintDate(d.date));
+  const l1 = data.map((d) =>
+    ((100 * d.attendance.numL1Attendees) / d.attendance.totalAttendees).toFixed(
+      1,
+    ),
+  );
+  const l2 = data.map((d) =>
+    ((100 * d.attendance.numL2Attendees) / d.attendance.totalAttendees).toFixed(
+      1,
+    ),
+  );
+  const l3 = data.map((d) =>
+    ((100 * d.attendance.numL3Attendees) / d.attendance.totalAttendees).toFixed(
+      1,
+    ),
+  );
+  const l4 = data.map((d) =>
+    ((100 * d.attendance.numL4Attendees) / d.attendance.totalAttendees).toFixed(
+      1,
+    ),
+  );
+  const socialOnly = data.map((d) =>
+    (
+      (100 * d.attendance.numSocialOnlyAttendees) /
+      d.attendance.totalAttendees
+    ).toFixed(1),
+  );
+
+  const colors = [
+    theme.palette.charts.l1,
+    theme.palette.charts.l2,
+    theme.palette.charts.l3,
+    theme.palette.charts.l4,
+    theme.palette.charts.socialOnly,
+  ];
+
+  return (
+    <Grid size={1}>
+      <DyosCard>
+        <Box sx={analyticsStyles.chartTitleContainer}>
+          <Typography variant="h6" sx={analyticsStyles.chartTitle}>
+            Class attendance (% of total attendees)
+          </Typography>
+          <Typography variant="subtitle" sx={analyticsStyles.chartSubtitle}>
+            Click a legend item to show/hide that line
+          </Typography>
+        </Box>
+        <LineChart
+          height={300}
+          series={[
+            { data: l1, label: "L1", showMark: false },
+            { data: l2, label: "L2", showMark: false },
+            { data: l3, label: "L3", showMark: false },
+            { data: l4, label: "L4", showMark: false },
+            {
+              data: socialOnly,
+              label: "Social Only",
+              showMark: false,
+            },
+          ]}
+          colors={colors}
+          xAxis={[{ scaleType: "point", data: xLabels, height: 28 }]}
+          yAxis={[{ width: 50, min: 0, max: 100 }]}
+          slotProps={{
+            legend: {
+              toggleVisibilityOnClick: true,
+            },
+          }}
+        />
+      </DyosCard>
+    </Grid>
+  );
+}
+
 function Attendance(props) {
   let data = props.data;
 
@@ -243,7 +319,9 @@ function Attendance(props) {
         sx={analyticsStyles.sectionContentContainer}
       >
         <TotalWeeklyAttendance data={data} />
+        <div></div>
         <ClassAttendance data={data} />
+        <PercentClassAttendance data={data} />
       </Grid>
     </Box>
   );

--- a/web/src/components/admin/analytics/attendance.jsx
+++ b/web/src/components/admin/analytics/attendance.jsx
@@ -1,9 +1,91 @@
 import theme from "@/common/theme";
 import analyticsStyles from "@/components/admin/analytics/analytics.styles";
-import { prettyPrintDate } from "@/components/admin/analytics/utils";
+import { prettyPrintDate, shortDate } from "@/components/admin/analytics/utils";
 import DyosCard from "@/components/common/card";
 import { Box, Grid, Typography } from "@mui/material";
 import { BarChart, LineChart } from "@mui/x-charts";
+
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+
+/**
+ * Given dataArrays (an array of numeric arrays),
+ * dates (an array of strings with the same length as an array in data),
+ * labels (one for each array in data),
+ * and colors (optional)
+ * displays summary statistics for each array in the data.
+ */
+function SummaryStats({ dataArrays, dates, labels }) {
+  // helper for calculating median (can also be used for quartiles)
+  const getElemAroundIndex = (arr, i) => {
+    if (i === Math.trunc(i)) {
+      return arr[i];
+    } else {
+      return (arr[Math.floor(i) - 1] + arr[Math.floor(i)]) / 2;
+    }
+  };
+
+  const summaries = dataArrays.map((arr) => {
+    const sum = arr.reduce((acc, num) => acc + num, 0);
+    const mean = Math.round(sum / arr.length);
+
+    const sortedData = arr.toSorted((a, b) => Number(a) - Number(b));
+    const median = getElemAroundIndex(sortedData, arr.length / 2);
+
+    const max = arr.reduce((a, b) => Math.max(a, b), -Infinity);
+    const maxIdx = arr.indexOf(max);
+    const min = arr.reduce((a, b) => Math.min(a, b), Infinity);
+    const minIdx = arr.indexOf(min);
+
+    return { mean, median, max, min, maxIdx, minIdx, sortedData };
+  });
+
+  return (
+    <details>
+      <summary>Show/hide summary stats</summary>
+      <LineChart
+        height={300}
+        series={summaries.map(({ sortedData }, i) => {
+          return { data: sortedData, label: `${labels[i]} (sorted)` };
+        })}
+        yAxis={[{ min: 0 }]}
+        margin={{ right: 64 }}
+      />
+
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell></TableCell>
+            <TableCell>Min</TableCell>
+            <TableCell>Avg</TableCell>
+            <TableCell>Median</TableCell>
+            <TableCell>Max</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {summaries.map(({ mean, median, max, min, maxIdx, minIdx }, i) => (
+            <TableRow>
+              <TableCell>{labels[i]}</TableCell>
+              <TableCell>
+                {min}
+                <br />({shortDate(dates[minIdx])})
+              </TableCell>
+              <TableCell>{mean}</TableCell>
+              <TableCell>{median}</TableCell>
+              <TableCell>
+                {max}
+                <br />({shortDate(dates[maxIdx])})
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </details>
+  );
+}
 
 function TotalWeeklyAttendance(props) {
   let data = props.data.weeklyStats;
@@ -25,6 +107,11 @@ function TotalWeeklyAttendance(props) {
           xAxis={[{ scaleType: "point", data: xLabels, height: 28 }]}
           yAxis={[{ min: 0 }]}
           margin={{ right: 64 }}
+        />
+        <SummaryStats
+          dataArrays={[weeklyAttendance]}
+          dates={data.map((d) => d.date)}
+          labels={["Total attendees"]}
         />
       </DyosCard>
     </Grid>
@@ -69,6 +156,11 @@ function ClassAttendance(props) {
           colors={colors}
           xAxis={[{ data: xLabels, height: 28 }]}
           yAxis={[{ width: 50 }]}
+        />
+        <SummaryStats
+          dataArrays={[l1, l2, l3, l4, socialOnly]}
+          dates={data.map((d) => d.date)}
+          labels={["L1", "L2", "L3", "L4", "Social"]}
         />
       </DyosCard>
     </Grid>

--- a/web/src/components/admin/analytics/attendance.jsx
+++ b/web/src/components/admin/analytics/attendance.jsx
@@ -11,6 +11,8 @@ import TableCell from "@mui/material/TableCell";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 
+const MAX_HISTOGRAM_SECTIONS = 10;
+
 /**
  * Given dataArrays (an array of numeric arrays),
  * dates (an array of strings with the same length as an array in data),
@@ -21,39 +23,83 @@ import TableRow from "@mui/material/TableRow";
 function SummaryStats({ dataArrays, dates, labels }) {
   // helper for calculating median (can also be used for quartiles)
   const getElemAroundIndex = (arr, i) => {
-    if (i === Math.trunc(i)) {
-      return arr[i];
+    if (i !== Math.floor(i)) {
+      return arr[Math.floor(i)];
     } else {
-      return (arr[Math.floor(i) - 1] + arr[Math.floor(i)]) / 2;
+      return (arr[i - 1] + arr[i]) / 2;
     }
   };
 
   const summaries = dataArrays.map((arr) => {
+    /* Summary stats */
     const sum = arr.reduce((acc, num) => acc + num, 0);
     const mean = Math.round(sum / arr.length);
 
     const sortedData = arr.toSorted((a, b) => Number(a) - Number(b));
     const median = getElemAroundIndex(sortedData, arr.length / 2);
 
-    const max = arr.reduce((a, b) => Math.max(a, b), -Infinity);
+    // these arrays should be small enough to safely spread them into function calls
+    const max = Math.max(...arr);
     const maxIdx = arr.indexOf(max);
-    const min = arr.reduce((a, b) => Math.min(a, b), Infinity);
+    const min = Math.min(...arr);
     const minIdx = arr.indexOf(min);
 
-    return { mean, median, max, min, maxIdx, minIdx, sortedData };
+    /* Data for the histogram - determine histogram thresholds based on range */
+    const range = max + 1 - min;
+    const thresholdDiff = Math.ceil(range / MAX_HISTOGRAM_SECTIONS);
+    const nSections = Math.ceil(range / thresholdDiff);
+
+    const thresholds = [...new Array(nSections)].map(
+      (_, i) => min + i * thresholdDiff,
+    );
+
+    const thresholdLabels =
+      thresholdDiff > 1
+        ? thresholds.map((n) => `${n}-${n + thresholdDiff - 1}`)
+        : thresholds;
+
+    const counts = thresholds.map(() => 0);
+    arr.forEach((n) => {
+      const bin = Math.floor((n - min) / thresholdDiff);
+      counts[bin] += 1;
+    });
+
+    return {
+      mean,
+      median,
+      max,
+      min,
+      maxIdx,
+      minIdx,
+      histogram: { thresholdLabels, counts },
+    };
   });
 
   return (
     <details>
       <summary>Show/hide summary stats</summary>
-      <LineChart
-        height={300}
-        series={summaries.map(({ sortedData }, i) => {
-          return { data: sortedData, label: `${labels[i]} (sorted)` };
-        })}
-        yAxis={[{ min: 0 }]}
-        margin={{ right: 64 }}
-      />
+      {summaries.map(({ histogram: { thresholdLabels, counts } }, i) => {
+        return (
+          <BarChart
+            key={labels[i]}
+            height={200}
+            xAxis={[
+              {
+                data: thresholdLabels,
+                label: `${labels[i]} histogram`,
+                scaleType: "band",
+                categoryGapRatio: 0,
+              },
+            ]}
+            series={[
+              {
+                data: counts,
+                type: "bar",
+              },
+            ]}
+          />
+        );
+      })}
 
       <Table>
         <TableHead>
@@ -67,7 +113,7 @@ function SummaryStats({ dataArrays, dates, labels }) {
         </TableHead>
         <TableBody>
           {summaries.map(({ mean, median, max, min, maxIdx, minIdx }, i) => (
-            <TableRow>
+            <TableRow key={labels[i]}>
               <TableCell>{labels[i]}</TableCell>
               <TableCell>
                 {min}

--- a/web/src/components/admin/analytics/payment.jsx
+++ b/web/src/components/admin/analytics/payment.jsx
@@ -54,7 +54,6 @@ function WeeklyMoneyPerPerson(props) {
 
   const allTimeRevenue = revenue.reduce((acc, num) => acc + num, 0);
   const payingPeople = numPayers.reduce((acc, num) => acc + num, 0);
-  console.log("All-time average revenue:", allTimeRevenue / payingPeople);
 
   return (
     <Grid size={1}>
@@ -74,6 +73,10 @@ function WeeklyMoneyPerPerson(props) {
           yAxis={[{ min: 0 }]}
           margin={{ right: 64 }}
         />
+        <Typography variant="subtitle" sx={analyticsStyles.chartSubtitle}>
+          All-time average amount paid: $
+          {(allTimeRevenue / payingPeople).toFixed(2)}
+        </Typography>
       </DyosCard>
     </Grid>
   );

--- a/web/src/components/admin/analytics/payment.jsx
+++ b/web/src/components/admin/analytics/payment.jsx
@@ -39,6 +39,46 @@ function TotalWeeklyMoney(props) {
   );
 }
 
+function WeeklyMoneyPerPerson(props) {
+  let data = props.data.weeklyStats;
+
+  const xLabels = data.map((d) => prettyPrintDate(d.date));
+
+  const revenue = data.map((d) => d.payment.totalAmountPaid);
+  const numPayers = data.map(
+    (d) => d.attendance.totalAttendees - d.exemptions.totalExemptions,
+  );
+  const weeklyAverageRevenue = revenue.map((amt, i) =>
+    (amt / numPayers[i]).toFixed(2),
+  );
+
+  const allTimeRevenue = revenue.reduce((acc, num) => acc + num, 0);
+  const payingPeople = numPayers.reduce((acc, num) => acc + num, 0);
+  console.log("All-time average revenue:", allTimeRevenue / payingPeople);
+
+  return (
+    <Grid size={1}>
+      <DyosCard>
+        <Box sx={analyticsStyles.chartTitleContainer}>
+          <Typography variant="h6" sx={analyticsStyles.chartTitle}>
+            Average at-door amount paid per person
+          </Typography>
+          <Typography variant="subtitle" sx={analyticsStyles.chartSubtitle}>
+            Excludes sponsors and people with an exemption or discount
+          </Typography>
+        </Box>
+        <LineChart
+          height={300}
+          series={[{ data: weeklyAverageRevenue, label: "Revenue" }]}
+          xAxis={[{ scaleType: "point", data: xLabels, height: 28 }]}
+          yAxis={[{ min: 0 }]}
+          margin={{ right: 64 }}
+        />
+      </DyosCard>
+    </Grid>
+  );
+}
+
 function PaymentMethods(props) {
   let data = props.data.weeklyStats;
 
@@ -179,6 +219,7 @@ function Payment(props) {
         sx={analyticsStyles.sectionContentContainer}
       >
         <TotalWeeklyMoney data={data} />
+        <WeeklyMoneyPerPerson data={data} />
         <PaymentMethods data={data} />
         <Sponsors data={data} />
         <TotalWeeklyProfit data={data} />

--- a/web/src/components/admin/analytics/utils.js
+++ b/web/src/components/admin/analytics/utils.js
@@ -5,6 +5,9 @@ import dayjs from "dayjs";
 export const prettyPrintDate = (dateString) =>
   formatDate(dayjs(new Date(dateString)), "MMM D, YYYY");
 
+export const shortDate = (dateString) =>
+  formatDate(dayjs(new Date(dateString)), "M/D/YY");
+
 export const dateStringToMonth = (dateString) =>
   formatDate(dayjs(new Date(dateString)), "MMM");
 


### PR DESCRIPTION
Random things I was curious about. Not requested by Riley or anything, so zero rush to review!

I have more things I'm curious about, but I think I would need edit access to the analytics Apps Script to implement them. I'm particularly interested in the times that people check in and the average amounts people are paying at the door based on which classes they take.

Changes:
- Summary stats and histograms for attendance
   - We probably need more data for the histograms to start to look like anything, but they were fun to put together lol
- Change class attendance to a line chart, change the colors (to add more contrast), and enable hiding lines
   - I think the bar chart is getting harder to read as the x-axis gets longer, and the lines make it easier to see certain trends (e.g. L1 is consistently least attended)
- New chart: attendance by class as percent of total attendees
   - I have some doubts about how useful/interpretable this chart is, might get rid of it later
- New chart: average amount paid per person (revenue ÷ the number of non-exemption attendees)

Interesting facts:
- L3 and L4 usually have almost the same number of students.
- Almost all L1 classes have had under 10 students.
- The most people came to L3/L4 when there was a guest instructor (5/28), but people didn't seem to pay more or less that night.
- Average amount paid doesn't vary a lot (±8% compared to the all-time average). The big swings in the revenue graph seem to be caused more by changes in number of attendees than by changes in how much people are willing to pay.