### PR TITLE
Add August events

### DIFF
--- a/web/src/components/home/subcomponents/upcoming_events_v2/event_card.jsx
+++ b/web/src/components/home/subcomponents/upcoming_events_v2/event_card.jsx
@@ -203,10 +203,12 @@ function EventCard(props) {
                   detail={messages.levelOneTopicHeader}
                   description={`${event.levelOneTopic}*`}
                 />
-                <EventCardDetail
-                  detail={messages.djHeader}
-                  description={!!event.dj ? event.dj : "DJ Riley"}
-                />
+                {event.dj && (
+                  <EventCardDetail
+                    detail={messages.djHeader}
+                    description={event.dj}
+                  />
+                )}
               </Box>
             )}
           </Box>

--- a/web/src/components/home/subcomponents/upcoming_events_v2/messages.js
+++ b/web/src/components/home/subcomponents/upcoming_events_v2/messages.js
@@ -43,7 +43,7 @@ const messages = {
   rsvpOnFacebook: "RSVP on Facebook",
   addToCalendar: "Add to calendar",
   google: "Google",
-  apple: "Apple",
+  apple: "Apple / Download .ics",
   outlook: "Outlook",
   advanceTopicHeader: "L3/L4 class topic: ",
   levelOneTopicHeader: "Intro class topic: ",

--- a/web/src/data/events_v2.js
+++ b/web/src/data/events_v2.js
@@ -274,9 +274,10 @@ const allEvents = [
   },
   {
     date: createDate("08/06/2026"),
-    noDyos: true,
-    title: "No DYOS",
-    subtitle: "See you at Swingtacular!",
+    title: "Swingtacular Week!",
+    subtitle:
+      "Join us for a shorter event with Alison, Joel, and Natasha! Our social dance will end at 10:30pm tonight.",
+    dj: "TBA",
   },
   {
     date: createDate("08/13/2026"),

--- a/web/src/data/events_v2.js
+++ b/web/src/data/events_v2.js
@@ -1,7 +1,9 @@
 // Events to be consumed by the UpcomingEventsV2 component
 
-import { createDate, getNextThursday } from "@/utils/date_utils";
+import { createDate, getNextThursday, nameOfMonth } from "@/utils/date_utils";
 
+// Important: if you change the key names here, also update the object accesses
+// in `allEvents` and `getThisMonthsEvents` below.
 const L1_TOPICS = {
   week1: "Left side pass, underarm pass, sugar push",
   week2: "Right side pass, closed position, whip",
@@ -9,7 +11,7 @@ const L1_TOPICS = {
   week4: "Left side pass, sugar push, spinning side pass",
 };
 
-const events = [
+const allEvents = [
   {
     date: createDate("01/08/2026"),
     title: "Footwork Variations week 1",
@@ -270,6 +272,21 @@ const events = [
     dj: "DJ Saucy",
     facebookLink: "",
   },
+  {
+    date: createDate("08/06/2026"),
+    noDyos: true,
+    title: "No DYOS",
+    subtitle: "See you at Swingtacular!",
+  },
+  {
+    date: createDate("08/13/2026"),
+  },
+  {
+    date: createDate("08/20/2026"),
+  },
+  {
+    date: createDate("08/27/2026"),
+  },
 ];
 
 // Example no DYOS item:
@@ -282,6 +299,17 @@ const events = [
 //   subtitle: "See you next week",
 // },
 
+// Example item with all possible info:
+// {
+//   date: createDate("mm/dd/yyyy"),
+//   title: "title",
+//   subtitle: "subtitle",
+//   advanceTopic: "class topic",
+//   levelOneTopic: L1_TOPICS.week1,
+//   dj: "DJ DJ",
+//   facebookLink: "https://www.example.com/",
+// },
+
 // Intro Class Scheduling doc: https://docs.google.com/spreadsheets/d/1JN8aU4991QY5T3iG_sc1WaUgN2MB8FN1t2rTakj4WOA/edit?gid=732299169#gid=732299169
 //   Specifies the class topics
 // Volunteer Sign Up Sheet: https://docs.google.com/spreadsheets/d/1xShbXzthXebT5oTHvB77HGHUBHOC3EyrIx05clzhVzI/edit?gid=0#gid=0
@@ -289,9 +317,32 @@ const events = [
 
 // TODO support specifying a particular month
 function getThisMonthsEvents() {
-  let thisMonth = getNextThursday().month();
+  const thisMonth = getNextThursday().month();
 
-  return events.filter((event) => event.date.month() === thisMonth);
+  const thisMonthEvents = allEvents.filter(
+    (event) => event.date.month() === thisMonth,
+  );
+
+  // Add default info to each event based on which week it is in the month
+  const monthName = nameOfMonth(thisMonth);
+  const weeksWithDyos = thisMonthEvents.filter((e) => !e.noDyos);
+  return thisMonthEvents.map((event) => {
+    if (event.noDyos) {
+      return event;
+    } else {
+      const week = weeksWithDyos.findIndex((e) => e.date === event.date) + 1;
+
+      // weeks beyond 4 repeat L4 topics
+      const l1TopicWeek = week > 4 || week < 1 ? 4 : week;
+
+      // if the event specified a title or L1 topic, those take precedence
+      return {
+        title: `${monthName} Week ${week}`,
+        levelOneTopic: L1_TOPICS[`week${l1TopicWeek}`],
+        ...event,
+      };
+    }
+  });
 }
 
 export default getThisMonthsEvents;

--- a/web/src/utils/date_utils.js
+++ b/web/src/utils/date_utils.js
@@ -43,10 +43,19 @@ function getNextThursday() {
   return today.day(4);
 }
 
+/**
+ * Return the name corresponding to the zero-indexed number passed in
+ * (e.g. 0 => January)
+ */
+function nameOfMonth(monthNum) {
+  return dayjs().month(monthNum).format("MMMM");
+}
+
 export {
   dateToHumanReadableString,
   formatDate,
   createDate,
   getBeginningOfTodayDate,
   getNextThursday,
+  nameOfMonth,
 };


### PR DESCRIPTION
Add August placeholder events. Also edit `getThisMonthsEvents` to specify the default title ("August Week X") and level 1 class topics we were previously adding manually, so that in the future, if the class topics/special info aren't available yet, we can just add a new object specifying the date.

Tested locally, but I won't deploy from this branch until next week!